### PR TITLE
refactor: consolidate duplicated cookie/session parsing

### DIFF
--- a/crates/rex_auth/src/authz_server/authorize.rs
+++ b/crates/rex_auth/src/authz_server/authorize.rs
@@ -1,4 +1,4 @@
-use crate::cookies::parse_cookies;
+use crate::cookies::cookies_from_header_map;
 use crate::session;
 use crate::AuthServer;
 use axum::extract::{Query, State};
@@ -89,11 +89,7 @@ pub async fn authorize_get_handler(
     let valid_scopes = crate::scopes::validate_scopes(&requested_scopes, &auth.config.mcp.scopes);
 
     // Check if user is authenticated (session cookie)
-    let cookie_header = headers
-        .get("cookie")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    let cookies = parse_cookies(cookie_header);
+    let cookies = cookies_from_header_map(&headers);
 
     let session_data = cookies
         .get(&auth.config.session.cookie_name)
@@ -229,11 +225,7 @@ pub async fn authorize_post_handler(
     }
 
     // Get user subject from session
-    let cookie_header = headers
-        .get("cookie")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    let cookies = parse_cookies(cookie_header);
+    let cookies = cookies_from_header_map(&headers);
 
     let subject = cookies
         .get(&auth.config.session.cookie_name)

--- a/crates/rex_auth/src/client_handlers.rs
+++ b/crates/rex_auth/src/client_handlers.rs
@@ -1,4 +1,4 @@
-use crate::cookies::parse_cookies;
+use crate::cookies::cookies_from_header_map;
 use crate::csrf;
 use crate::session::{self, SessionData};
 use crate::AuthServer;
@@ -99,11 +99,7 @@ pub async fn callback_handler(
         }
     };
 
-    let cookie_header = headers
-        .get("cookie")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    let cookies = parse_cookies(cookie_header);
+    let cookies = cookies_from_header_map(&headers);
 
     let expected_state = match cookies.get("__rex_auth_state") {
         Some(s) => s,
@@ -250,11 +246,7 @@ pub async fn session_handler(
     State(auth): State<Arc<AuthServer>>,
     headers: axum::http::HeaderMap,
 ) -> Response {
-    let cookie_header = headers
-        .get("cookie")
-        .and_then(|v| v.to_str().ok())
-        .unwrap_or("");
-    let cookies = parse_cookies(cookie_header);
+    let cookies = cookies_from_header_map(&headers);
 
     let session = cookies
         .get(&auth.config.session.cookie_name)
@@ -286,8 +278,7 @@ pub fn extract_session(
     session_key: &[u8; 32],
     cookie_name: &str,
 ) -> Option<serde_json::Value> {
-    let cookie_header = headers.get("cookie").or_else(|| headers.get("Cookie"))?;
-    let cookies = parse_cookies(cookie_header);
+    let cookies = crate::cookies::cookies_from_headers(headers);
     let encrypted = cookies.get(cookie_name)?;
     let data = session::decrypt_session(encrypted, session_key)?;
     serde_json::to_value(&data).ok()

--- a/crates/rex_auth/src/cookies.rs
+++ b/crates/rex_auth/src/cookies.rs
@@ -19,7 +19,7 @@ pub fn parse_cookies(cookie_header: &str) -> HashMap<String, String> {
         .collect()
 }
 
-/// Extract cookies from a headers map (case-insensitive lookup for "cookie").
+/// Extract cookies from a `HashMap<String, String>` headers map (case-insensitive lookup for "cookie").
 pub fn cookies_from_headers(headers: &HashMap<String, String>) -> HashMap<String, String> {
     // Try both common casings
     if let Some(cookie_header) = headers.get("cookie").or_else(|| headers.get("Cookie")) {
@@ -27,6 +27,15 @@ pub fn cookies_from_headers(headers: &HashMap<String, String>) -> HashMap<String
     } else {
         HashMap::new()
     }
+}
+
+/// Extract cookies from an Axum `HeaderMap`.
+pub fn cookies_from_header_map(headers: &axum::http::HeaderMap) -> HashMap<String, String> {
+    headers
+        .get("cookie")
+        .and_then(|v| v.to_str().ok())
+        .map(parse_cookies)
+        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/crates/rex_auth/src/lib.rs
+++ b/crates/rex_auth/src/lib.rs
@@ -15,6 +15,7 @@ pub mod session;
 pub mod store;
 
 pub use config::AuthConfig;
+pub use cookies::{cookies_from_header_map, cookies_from_headers, parse_cookies};
 pub use error::AuthError;
 pub use jwt::AccessTokenClaims;
 pub use keys::KeyManager;

--- a/crates/rex_server/src/core.rs
+++ b/crates/rex_server/src/core.rs
@@ -1,3 +1,4 @@
+use rex_auth::cookies_from_headers;
 use rex_core::{
     DataStrategy, MiddlewareAction, MiddlewareResult, ProjectConfig, ServerSidePropsContext,
 };
@@ -14,32 +15,6 @@ pub(crate) fn extract_session(
         .auth
         .as_ref()
         .and_then(|auth| auth.extract_session(headers))
-}
-
-/// Parse a `Cookie` header value into name-value pairs.
-pub(crate) fn parse_cookies(cookie_header: &str) -> HashMap<String, String> {
-    cookie_header
-        .split(';')
-        .filter_map(|pair| {
-            let pair = pair.trim();
-            let eq = pair.find('=')?;
-            let name = pair[..eq].trim();
-            let value = pair[eq + 1..].trim();
-            if name.is_empty() {
-                return None;
-            }
-            Some((name.to_string(), value.to_string()))
-        })
-        .collect()
-}
-
-/// Extract cookies from a headers map.
-pub(crate) fn cookies_from_headers(headers: &HashMap<String, String>) -> HashMap<String, String> {
-    if let Some(cookie_header) = headers.get("cookie").or_else(|| headers.get("Cookie")) {
-        parse_cookies(cookie_header)
-    } else {
-        HashMap::new()
-    }
 }
 
 use crate::document::{assemble_document, DocumentParams};

--- a/crates/rex_server/src/handlers.rs
+++ b/crates/rex_server/src/handlers.rs
@@ -12,11 +12,11 @@ use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use tracing::{debug, error, info};
 
-use crate::core::cookies_from_headers;
 use crate::document::{
     assemble_body_tail, assemble_document, assemble_head_shell, assemble_rsc_body_tail,
     assemble_rsc_head_shell, DocumentDescriptor, DocumentParams,
 };
+use rex_auth::cookies_from_headers;
 
 /// State that can change during dev-mode rebuilds.
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- Remove duplicate `parse_cookies`/`cookies_from_headers` from `rex_server::core` (already depends on `rex_auth`)
- Add `cookies_from_header_map` helper in `rex_auth::cookies` for Axum `HeaderMap` extraction
- Re-export cookie utilities from `rex_auth` crate root
- Replace 4 repeated 3-line cookie extraction patterns in auth handlers with single helper call

Net: -32 lines, single source of truth for cookie parsing.

## Test plan
- [x] `cargo check` — zero warnings
- [x] `cargo test` — all tests pass (including 8 cookie-specific tests)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)