### PR TITLE
chore: remove unnecessary API route stubs from fixtures

### DIFF
--- a/fixtures/custom-server/pages/api/hello.ts
+++ b/fixtures/custom-server/pages/api/hello.ts
@@ -1,3 +1,0 @@
-export default function handler(req, res) {
-  res.status(200).json({ message: "Hello from API!", method: req.method });
-}

--- a/fixtures/tailwind/pages/api/hello.ts
+++ b/fixtures/tailwind/pages/api/hello.ts
@@ -1,3 +1,0 @@
-export default function handler(req: any, res: any) {
-  res.status(200).json({ message: "Hello from Rex API!", method: req.method });
-}


### PR DESCRIPTION
## Summary
- Remove `pages/api/hello.ts` from `fixtures/custom-server/` and `fixtures/tailwind/`
- These fixtures don't need API route examples — they exist to test custom server and Tailwind integration respectively

## Test plan
- [x] `cargo check` passes
- [x] `cargo test` passes
- [x] No fixture tests depend on these API routes

🤖 Generated with [Claude Code](https://claude.com/claude-code)