### PR TITLE
fix(docker): bind to 0.0.0.0 in production mode

### DIFF
--- a/crates/rex_cli/src/main.rs
+++ b/crates/rex_cli/src/main.rs
@@ -6,6 +6,7 @@ use rayon::prelude::*;
 use rex_build::build_bundles;
 use rex_core::{ProjectConfig, RexConfig};
 use rex_router::scan_project;
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -29,6 +30,10 @@ enum Commands {
         #[arg(short, long, default_value = "3000")]
         port: u16,
 
+        /// Host to bind to (use 0.0.0.0 to listen on all interfaces)
+        #[arg(short = 'H', long, default_value = "127.0.0.1")]
+        host: IpAddr,
+
         /// Project root directory
         #[arg(long, default_value = ".")]
         root: PathBuf,
@@ -50,6 +55,10 @@ enum Commands {
         /// Port to listen on
         #[arg(short, long, default_value = "3000")]
         port: u16,
+
+        /// Host to bind to
+        #[arg(short = 'H', long, default_value = "0.0.0.0")]
+        host: IpAddr,
 
         /// Project root directory
         #[arg(long, default_value = ".")]
@@ -134,7 +143,12 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Dev { port, root, no_tui } => {
+        Commands::Dev {
+            port,
+            host,
+            root,
+            no_tui,
+        } => {
             let root = std::fs::canonicalize(&root)?;
             let project_config = ProjectConfig::load(&root)?;
             let is_terminal = std::io::IsTerminal::is_terminal(&std::io::stdout());
@@ -143,7 +157,7 @@ async fn main() -> Result<()> {
             if tui_enabled {
                 let log_buffer = init_tui_tracing();
                 let log_buffer_fallback = log_buffer.clone();
-                let result = cmd_dev(root, port, true, Some(log_buffer)).await;
+                let result = cmd_dev(root, port, host, true, Some(log_buffer)).await;
                 if result.is_err() {
                     // The TUI never started — dump buffered logs to stderr
                     // so the user can see what happened before the error.
@@ -154,16 +168,16 @@ async fn main() -> Result<()> {
                 result
             } else {
                 init_plain_tracing();
-                cmd_dev(root, port, false, None).await
+                cmd_dev(root, port, host, false, None).await
             }
         }
         Commands::Build { root } => {
             init_plain_tracing();
             cmd_build(root).await
         }
-        Commands::Start { port, root } => {
+        Commands::Start { port, host, root } => {
             init_plain_tracing();
-            cmd_start(root, port).await
+            cmd_start(root, port, host).await
         }
         Commands::Lint {
             root,
@@ -192,16 +206,17 @@ async fn main() -> Result<()> {
 async fn cmd_dev(
     root: PathBuf,
     port: u16,
+    host: IpAddr,
     tui_enabled: bool,
     log_buffer: Option<LogBuffer>,
 ) -> Result<()> {
     let start = std::time::Instant::now();
 
     // Bind the port early — fail fast on conflicts before the expensive build.
-    let addr = std::net::SocketAddr::from(([127, 0, 0, 1], port));
+    let addr = std::net::SocketAddr::new(host, port);
     let listener = tokio::net::TcpListener::bind(addr)
         .await
-        .with_context(|| format!("failed to bind port {port} — is another server running?"))?;
+        .with_context(|| format!("failed to bind {addr} — is another server running?"))?;
 
     if !tui_enabled {
         print_mascot_header(env!("CARGO_PKG_VERSION"), "");
@@ -211,6 +226,7 @@ async fn cmd_dev(
         root: root.clone(),
         dev: true,
         port,
+        host,
     })
     .await?;
 
@@ -1260,7 +1276,7 @@ fn print_route_summary_with_manifest(
     }
 }
 
-async fn cmd_start(root: PathBuf, port: u16) -> Result<()> {
+async fn cmd_start(root: PathBuf, port: u16, host: IpAddr) -> Result<()> {
     let start = std::time::Instant::now();
 
     print_mascot_header(env!("CARGO_PKG_VERSION"), "(production)");
@@ -1269,6 +1285,7 @@ async fn cmd_start(root: PathBuf, port: u16) -> Result<()> {
         root,
         dev: false,
         port,
+        host,
     })
     .await?;
 

--- a/crates/rex_napi/src/rex_instance.rs
+++ b/crates/rex_napi/src/rex_instance.rs
@@ -98,6 +98,7 @@ pub async fn create_rex(options: RexOptions) -> Result<RexInstance> {
         root: options.root.into(),
         dev: is_dev,
         port: 0, // NAPI doesn't serve directly
+        ..Default::default()
     })
     .await
     .map_err(|e| Error::from_reason(e.to_string()))?;

--- a/crates/rex_python/src/lib.rs
+++ b/crates/rex_python/src/lib.rs
@@ -123,6 +123,7 @@ impl Renderer {
                 root: root.into(),
                 dev,
                 port: 0,
+                ..Default::default()
             }))
             .map_err(to_py_err)?;
 
@@ -306,6 +307,7 @@ mod tests {
             root: fixtures,
             dev: false,
             port: 0,
+            ..Default::default()
         }))
         .unwrap()
     });

--- a/crates/rex_server/src/rex.rs
+++ b/crates/rex_server/src/rex.rs
@@ -8,6 +8,7 @@ use rex_core::{DataStrategy, ProjectConfig, RexConfig, ServerSidePropsContext};
 use rex_router::{scan_project, RouteTrie, ScanResult};
 use rex_v8::{init_v8, IsolatePool};
 use std::collections::HashMap;
+use std::net::IpAddr;
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use tracing::debug;
@@ -21,6 +22,8 @@ pub struct RexOptions {
     pub dev: bool,
     /// Port to listen on (used by `serve()`).
     pub port: u16,
+    /// Host/IP address to bind to (e.g. 127.0.0.1 for local, 0.0.0.0 for all interfaces).
+    pub host: IpAddr,
 }
 
 impl Default for RexOptions {
@@ -29,6 +32,7 @@ impl Default for RexOptions {
             root: PathBuf::from("."),
             dev: false,
             port: 3000,
+            host: IpAddr::V4(std::net::Ipv4Addr::LOCALHOST),
         }
     }
 }
@@ -84,6 +88,7 @@ pub struct Rex {
     static_dir: PathBuf,
     scan: ScanResult,
     port: u16,
+    host: IpAddr,
 }
 
 impl Rex {
@@ -157,6 +162,7 @@ impl Rex {
             static_dir,
             project_config,
             opts.port,
+            opts.host,
         )
         .await
     }
@@ -217,6 +223,7 @@ impl Rex {
             static_dir,
             project_config,
             opts.port,
+            opts.host,
         )
         .await
     }
@@ -233,6 +240,7 @@ impl Rex {
         static_dir: PathBuf,
         project_config: ProjectConfig,
         port: u16,
+        host: IpAddr,
     ) -> Result<Self> {
         let trie = RouteTrie::from_routes(&scan.routes);
         let api_trie = RouteTrie::from_routes(&scan.api_routes);
@@ -310,6 +318,7 @@ impl Rex {
             static_dir,
             scan,
             port,
+            host,
         })
     }
 
@@ -486,10 +495,10 @@ impl Rex {
         server.build_router_with_extra(extra)
     }
 
-    /// Bind to the configured port and serve.
+    /// Bind to the configured host and port and serve.
     pub async fn serve(self) -> Result<()> {
         let router = self.router();
-        let addr = std::net::SocketAddr::from(([127, 0, 0, 1], self.port));
+        let addr = std::net::SocketAddr::new(self.host, self.port);
 
         tracing::info!("Rex server listening on http://{addr}");
 
@@ -504,6 +513,7 @@ impl Rex {
         RexServer::from_state(
             self.state.clone(),
             self.port,
+            self.host,
             self.static_dir.clone(),
             self.config.project_root.clone(),
         )

--- a/crates/rex_server/src/server.rs
+++ b/crates/rex_server/src/server.rs
@@ -8,7 +8,7 @@ use rex_build::AssetManifest;
 use rex_core::ProjectConfig;
 use rex_router::RouteTrie;
 use rex_v8::IsolatePool;
-use std::net::SocketAddr;
+use std::net::{IpAddr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use tower_http::compression::CompressionLayer;
@@ -35,11 +35,13 @@ pub struct ServerConfig {
     /// App route trie for RSC app/ routes. None if no app/ directory.
     pub app_route_trie: Option<RouteTrie>,
     pub has_mcp_tools: bool,
+    pub host: IpAddr,
 }
 
 pub struct RexServer {
     state: Arc<AppState>,
     port: u16,
+    host: IpAddr,
     static_dir: PathBuf,
     project_root: PathBuf,
 }
@@ -91,6 +93,7 @@ impl RexServer {
         Self {
             state,
             port: config.port,
+            host: config.host,
             static_dir: config.static_dir,
             project_root: config.project_root,
         }
@@ -100,12 +103,14 @@ impl RexServer {
     pub fn from_state(
         state: Arc<AppState>,
         port: u16,
+        host: IpAddr,
         static_dir: PathBuf,
         project_root: PathBuf,
     ) -> Self {
         Self {
             state,
             port,
+            host,
             static_dir,
             project_root,
         }
@@ -161,7 +166,7 @@ impl RexServer {
 
     pub async fn serve(self) -> Result<()> {
         let router = self.build_router();
-        let addr = SocketAddr::from(([127, 0, 0, 1], self.port));
+        let addr = SocketAddr::new(self.host, self.port);
 
         info!("Rex server listening on http://{addr}");
 


### PR DESCRIPTION
## Summary
- `rex start` was hardcoding `127.0.0.1` as the bind address, making the server unreachable inside Docker containers (e.g. Railway health checks fail because they can't reach localhost from outside the container)
- `rex start` now defaults to `0.0.0.0` (all interfaces), `rex dev` keeps `127.0.0.1` (local only)
- Both commands accept a new `--host` / `-H` flag to override the bind address

## Test plan
- [x] `cargo check` — zero warnings
- [x] `cargo test` — all tests pass
- [x] Pre-commit hooks pass (check, clippy, fmt, coverage, oxlint, typecheck)
- [x] E2e tests pass (25/25)
- [ ] Deploy to Railway and verify health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)