### PR TITLE
fix(ci): prevent beta-release from double-triggering

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -7,6 +7,10 @@ on:
     paths-ignore:
       - 'Cargo.lock'
 
+concurrency:
+  group: beta-release-${{ github.head_ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   packages: write

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,8 +70,15 @@ jobs:
           git add Cargo.lock '*/package-lock.json' 'packages/*/package-lock.json'
           if [ -n "$(git diff --cached --name-only)" ]; then
             git commit -m "chore: update lockfiles"
+            # Push with GITHUB_TOKEN so this commit does NOT re-trigger workflows.
+            # The checkout step uses RELEASE_PAT (needed to write to the PR branch),
+            # but PAT-based pushes trigger workflow runs, causing beta-release to
+            # double-fire. GITHUB_TOKEN pushes are deliberately ignored by Actions.
+            git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}"
             git push
           fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   build-linux:
     name: Build Linux (x86_64)


### PR DESCRIPTION
## Summary

- Switch the lockfile update push in `release-please.yml` from `RELEASE_PAT` to `GITHUB_TOKEN`, since pushes made with `GITHUB_TOKEN` are deliberately ignored by GitHub Actions and won't re-trigger workflows
- Add a concurrency group with `cancel-in-progress: true` to `beta-release.yml` as defense-in-depth

**Root cause:** The `update-lockfiles` job pushes a commit to the release-please PR using `RELEASE_PAT`. PAT-based pushes trigger `pull_request: synchronize` events, causing `beta-release.yml` to fire a second time for the same PR update.

## Test plan

- [ ] Merge a commit to main that triggers release-please
- [ ] Verify only one beta-release workflow run appears (not two)
- [ ] Verify lockfile updates still get pushed to the release PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)