### PR TITLE
ci: add pull_request trigger to CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,8 @@ name: "CodeQL Advanced"
 on:
   push:
     branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
   merge_group:
   schedule:
     - cron: '23 10 * * 3'


### PR DESCRIPTION
## Summary
- Adds `pull_request` trigger (targeting `main`) to the CodeQL workflow
- Without this, CodeQL checks never run on PRs, so required status checks are never satisfied and PRs can't enter the merge queue

## Test plan
- [x] Verify this PR itself triggers CodeQL checks
- [x] Confirm PRs can enter merge queue once CodeQL checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)