### PR TITLE
fix(router): pass app_dir to scan_project instead of hardcoding

### DIFF
--- a/crates/rex_cli/src/main.rs
+++ b/crates/rex_cli/src/main.rs
@@ -388,7 +388,7 @@ async fn cmd_build(root: PathBuf) -> Result<()> {
     let start = std::time::Instant::now();
     debug!("Building for production...");
 
-    let scan = scan_project(&config.project_root, &config.pages_dir)?;
+    let scan = scan_project(&config.project_root, &config.pages_dir, &config.app_dir)?;
     debug!(routes = scan.routes.len(), "Routes scanned");
 
     let project_config = ProjectConfig::load(&config.project_root)?;

--- a/crates/rex_dev/src/rebuild.rs
+++ b/crates/rex_dev/src/rebuild.rs
@@ -27,7 +27,7 @@ pub async fn handle_file_event(
             let t0 = Instant::now();
 
             // Rescan, rebuild, reload isolates, update hot state
-            let scan = scan_project(&config.project_root, &config.pages_dir)?;
+            let scan = scan_project(&config.project_root, &config.pages_dir, &config.app_dir)?;
             let t_scan = t0.elapsed();
 
             // Get project_config from current hot state for build aliases
@@ -140,7 +140,7 @@ pub async fn handle_file_event(
         }
         FileEventKind::PageRemoved => {
             // Full rebuild: routes changed, need new trie + manifest
-            let scan = scan_project(&config.project_root, &config.pages_dir)?;
+            let scan = scan_project(&config.project_root, &config.pages_dir, &config.app_dir)?;
 
             // Get project_config from current hot state for build aliases
             let project_config = {

--- a/crates/rex_python/src/lib.rs
+++ b/crates/rex_python/src/lib.rs
@@ -227,7 +227,8 @@ impl Renderer {
         let project_config =
             rex_core::ProjectConfig::load(&config.project_root).map_err(to_py_err)?;
         let scan =
-            rex_router::scan_project(&config.project_root, &config.pages_dir).map_err(to_py_err)?;
+            rex_router::scan_project(&config.project_root, &config.pages_dir, &config.app_dir)
+                .map_err(to_py_err)?;
 
         let build_result = self
             .rt
@@ -321,7 +322,8 @@ mod tests {
             .unwrap()
             .join("fixtures/basic");
         let pages_dir = fixtures.join("pages");
-        let scan = rex_router::scan_project(&fixtures, &pages_dir).unwrap();
+        let app_dir = fixtures.join("app");
+        let scan = rex_router::scan_project(&fixtures, &pages_dir, &app_dir).unwrap();
         let map = build_module_map(&scan);
 
         assert!(map.contains_key("index"));

--- a/crates/rex_router/src/scanner.rs
+++ b/crates/rex_router/src/scanner.rs
@@ -114,7 +114,11 @@ pub fn scan_mcp_tools(project_root: &Path) -> Vec<McpToolRoute> {
 /// Scan pages and detect middleware. Convenience wrapper for callers that have the project root.
 ///
 /// Also scans app/ directory if present for RSC/App Router support.
-pub fn scan_project(project_root: &Path, pages_dir: &Path) -> anyhow::Result<ScanResult> {
+pub fn scan_project(
+    project_root: &Path,
+    pages_dir: &Path,
+    app_dir: &Path,
+) -> anyhow::Result<ScanResult> {
     let mut scan = if pages_dir.exists() {
         scan_pages(pages_dir)?
     } else {
@@ -134,8 +138,7 @@ pub fn scan_project(project_root: &Path, pages_dir: &Path) -> anyhow::Result<Sca
     scan.middleware = find_middleware(project_root);
 
     // Scan app/ directory for RSC routes
-    let app_dir = project_root.join("app");
-    if let Some(app_scan) = crate::app_scanner::scan_app(&app_dir)? {
+    if let Some(app_scan) = crate::app_scanner::scan_app(app_dir)? {
         debug!(routes = app_scan.routes.len(), "App router routes scanned");
         scan.app_scan = Some(app_scan);
     }
@@ -466,7 +469,8 @@ mod tests {
         std::fs::create_dir_all(&mcp).unwrap();
         std::fs::write(mcp.join("search.ts"), "export default function(){}").unwrap();
 
-        let scan = scan_project(&tmp, &pages).unwrap();
+        let app = tmp.join("app");
+        let scan = scan_project(&tmp, &pages, &app).unwrap();
         assert_eq!(scan.routes.len(), 1);
         assert!(scan.middleware.is_some());
         assert_eq!(scan.mcp_tools.len(), 1);
@@ -481,10 +485,52 @@ mod tests {
         let _ = std::fs::remove_dir_all(&tmp);
         std::fs::create_dir_all(&tmp).unwrap();
         let pages = tmp.join("pages"); // doesn't exist
+        let app = tmp.join("app"); // doesn't exist
 
-        let scan = scan_project(&tmp, &pages).unwrap();
+        let scan = scan_project(&tmp, &pages, &app).unwrap();
         assert!(scan.routes.is_empty());
         assert!(scan.api_routes.is_empty());
+
+        let _ = std::fs::remove_dir_all(&tmp);
+    }
+
+    #[test]
+    fn test_scan_project_src_app_dir() {
+        let tmp = std::env::temp_dir().join("rex_test_scan_src_app");
+        let _ = std::fs::remove_dir_all(&tmp);
+
+        // Simulate a src/app/ project with route groups (no root layout)
+        let app_dir = tmp.join("src/app");
+        let frontend = app_dir.join("(frontend)");
+        std::fs::create_dir_all(frontend.join("about")).unwrap();
+        std::fs::write(
+            frontend.join("layout.tsx"),
+            "export default function Layout({children}) { return children }",
+        )
+        .unwrap();
+        std::fs::write(
+            frontend.join("page.tsx"),
+            "export default function Home() { return 'home' }",
+        )
+        .unwrap();
+        std::fs::write(
+            frontend.join("about/page.tsx"),
+            "export default function About() { return 'about' }",
+        )
+        .unwrap();
+
+        let pages = tmp.join("src/pages"); // doesn't exist
+        let scan = scan_project(&tmp, &pages, &app_dir).unwrap();
+
+        // Should find app routes via the app_dir parameter
+        assert!(scan.app_scan.is_some());
+        let app_scan = scan.app_scan.unwrap();
+        assert_eq!(app_scan.routes.len(), 2);
+        assert!(app_scan.root_layout.is_none()); // route-group-only
+
+        let patterns: Vec<&str> = app_scan.routes.iter().map(|r| r.pattern.as_str()).collect();
+        assert!(patterns.contains(&"/"));
+        assert!(patterns.contains(&"/about"));
 
         let _ = std::fs::remove_dir_all(&tmp);
     }

--- a/crates/rex_server/src/rex.rs
+++ b/crates/rex_server/src/rex.rs
@@ -105,7 +105,7 @@ impl Rex {
 
         // Scan pages + middleware
         debug!("Scanning routes...");
-        let scan = scan_project(&config.project_root, &config.pages_dir)?;
+        let scan = scan_project(&config.project_root, &config.pages_dir, &config.app_dir)?;
         debug!(
             routes = scan.routes.len(),
             has_app = scan.app.is_some(),
@@ -179,7 +179,7 @@ impl Rex {
         let manifest = AssetManifest::load(&config.manifest_path())?;
 
         // Scan routes + middleware (for trie)
-        let scan = scan_project(&config.project_root, &config.pages_dir)?;
+        let scan = scan_project(&config.project_root, &config.pages_dir, &config.app_dir)?;
 
         // Initialize V8
         init_v8();


### PR DESCRIPTION
## Summary

- `scan_project()` was hardcoding `project_root.join("app")` for the app directory scan, bypassing the resolved `config.app_dir` which correctly points to `src/app/` when using the src directory convention
- This meant the `src/` directory support added in #132 was not actually wired through — the config resolved `src/app/` correctly but the scanner never used it
- Now `scan_project()` accepts an `app_dir` parameter and all callers pass `config.app_dir`

## Test plan

- [x] All 509 unit/integration tests pass
- [x] All 25 e2e tests pass
- [x] Pre-commit hooks pass (check, clippy, coverage, fmt, oxlint)
- [ ] Manual test: `npx @limlabs/rex@beta dev` on a project with `src/app/` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)