### PR TITLE
perf(ci): use feature flags to speed up docs site build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,17 +30,17 @@ jobs:
         run: npm install
         working-directory: docs
 
-      - name: Build Rex
-        run: cargo build --release
+      - name: Build Rex (export-only, skips dev/lint)
+        run: cargo build --bin rex --no-default-features --features build --release
 
-      - name: Build docs site
-        run: ./target/release/rex build
+      - name: Export docs site
+        run: ./target/release/rex export --force
         working-directory: docs
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: docs/.rex/build/client
+          path: docs/.rex/export
 
   deploy:
     environment:


### PR DESCRIPTION
## Summary

- Uses `--no-default-features --features build` when building rex for docs export, skipping compilation of dev server, TUI, and linter
- Switches from `rex build` to `rex export --force` for static HTML output

## Test plan

- [x] Pre-commit hooks pass
- [x] E2E tests pass (29/29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)