### PR TITLE
fix(ci): prevent beta-release double-fire from lockfile push

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           ref: ${{ needs.release-please.outputs.pr_branch }}
           token: ${{ secrets.RELEASE_PAT }}
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -71,9 +72,11 @@ jobs:
           if [ -n "$(git diff --cached --name-only)" ]; then
             git commit -m "chore: update lockfiles"
             # Push with GITHUB_TOKEN so this commit does NOT re-trigger workflows.
-            # The checkout step uses RELEASE_PAT (needed to write to the PR branch),
-            # but PAT-based pushes trigger workflow runs, causing beta-release to
-            # double-fire. GITHUB_TOKEN pushes are deliberately ignored by Actions.
+            # The checkout uses RELEASE_PAT (needed for the initial fetch) but sets
+            # persist-credentials: false so the PAT's extraheader isn't saved in
+            # git config. Without that, the extraheader would override the URL token
+            # below, causing the push to authenticate as the PAT — which triggers
+            # workflow runs and makes beta-release double-fire.
             git remote set-url origin "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}"
             git push
           fi


### PR DESCRIPTION
## Summary
- `actions/checkout` with `RELEASE_PAT` persists an `http.extraheader` in git config that overrides the URL-embedded `GITHUB_TOKEN`, so the lockfile push was still authenticating as the PAT — triggering a `synchronize` event that re-fired `beta-release.yml`
- Added `persist-credentials: false` to the checkout step so the PAT extraheader is not saved, letting the `GITHUB_TOKEN` URL actually take effect for the push

## Test plan
- [ ] Merge a commit to main that triggers release-please to update the release PR
- [ ] Verify only one beta-release workflow run fires (no cancelled + re-triggered pair)

🤖 Generated with [Claude Code](https://claude.com/claude-code)