### PR TITLE
ci(docker): add BuildKit caching and parallel target builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,10 +101,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Build rex image (runtime + build stages)
-        run: |
-          docker build --target app-build -t ghcr.io/limlabs/rex:ci-build .
-          docker build -t ghcr.io/limlabs/rex:ci .
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build rex images (app-build + runtime in parallel)
+        uses: docker/bake-action@v6
+        with:
+          load: true
+          set: |
+            *.cache-from=type=gha,scope=docker
+            *.cache-to=type=gha,scope=docker,mode=max
 
       - name: Build railway fixture
         run: docker build --build-arg REX_VERSION=ci -t rex-railway-fixture fixtures/railway

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,30 @@
+// docker-bake.hcl — build both Docker targets in parallel, sharing the builder stage.
+// Usage: docker buildx bake --load
+
+variable "TAG_PREFIX" {
+  default = "ghcr.io/limlabs/rex"
+}
+
+variable "TAG_SUFFIX" {
+  default = "ci"
+}
+
+group "default" {
+  targets = ["app-build", "runtime"]
+}
+
+target "app-build" {
+  dockerfile = "Dockerfile"
+  tags       = ["${TAG_PREFIX}:${TAG_SUFFIX}-build"]
+  target     = "app-build"
+  cache-from = ["type=gha,scope=docker"]
+  cache-to   = ["type=gha,scope=docker,mode=max"]
+  output     = ["type=docker"]
+}
+
+target "runtime" {
+  dockerfile = "Dockerfile"
+  tags       = ["${TAG_PREFIX}:${TAG_SUFFIX}"]
+  cache-from = ["type=gha,scope=docker"]
+  output     = ["type=docker"]
+}


### PR DESCRIPTION
## Summary
- Add **GHA layer caching** to the Docker CI job via `docker/bake-action` with `type=gha` cache backend. This caches Docker layers (including the expensive Rust compilation in the builder stage) across CI runs, so subsequent builds skip recompilation when `Cargo.toml`/`Cargo.lock`/source haven't changed.
- Add `docker-bake.hcl` to build both the `app-build` and `runtime` targets **in parallel**, sharing the builder stage.
- Replaces the two sequential `docker build` commands with a single `docker buildx bake` invocation.

## What changes
- `.github/workflows/ci.yml`: Docker job now uses `docker/setup-buildx-action` + `docker/bake-action` with GHA cache
- `docker-bake.hcl`: New bake file defining both targets with shared cache config

## Expected impact
- **Cache hit**: Docker build drops from ~10+ min (full Rust recompile) to ~1-2 min (layer restore + final stages)
- **Cache miss**: Roughly same as before, plus a few seconds for cache upload
- **Parallel targets**: Minor additional speedup from building app-build and runtime concurrently

## Test plan
- [ ] CI Docker job passes on this PR (first run will be a cache miss, establishing the cache)
- [ ] Subsequent runs on the same branch hit the cache and complete faster
- [ ] Railway fixture build still works (uses the locally-loaded images)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add BuildKit caching and parallel Docker target builds via `docker-bake`
> - Replaces serial `docker build` commands in the CI workflow with `docker/bake-action@v6`, building both `app-build` and `runtime` targets in parallel.
> - Adds [docker-bake.hcl](https://github.com/limlabs/rex/pull/145/files#diff-870f6fe23fc034f008f5203ee1e628d7bfa65a49095d5a4688db498328449ed2) defining the two targets with configurable `TAG_PREFIX`/`TAG_SUFFIX` variables and GitHub Actions layer caching (`type=gha`).
> - Sets up Docker Buildx via `docker/setup-buildx-action@v3` as a prerequisite step in the CI workflow.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 82b50a8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->