### PR TITLE
ci: use self-hosted runners for Docker builds

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -179,7 +179,7 @@ jobs:
   docker:
     name: Docker (beta)
     needs: check-release-pr
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
   docker:
     name: Docker Build
     if: ${{ !startsWith(github.head_ref || '', 'release-please--') }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -226,7 +226,7 @@ jobs:
     name: Docker
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Switch all Docker build jobs to `self-hosted` runners across CI, release, and beta-release workflows
- Affects `docker` jobs in `ci.yml`, `release-please.yml`, and `beta-release.yml`

## Test plan
- [ ] Verify CI Docker build job picks up a self-hosted runner
- [ ] Verify beta-release Docker job works on self-hosted
- [ ] Verify release Docker job works on self-hosted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Use self-hosted runners for Docker builds in CI workflows
> Switches the `runs-on` field from `ubuntu-latest` to `self-hosted` in the Docker jobs across [beta-release.yml](.github/workflows/beta-release.yml), [ci.yml](.github/workflows/ci.yml), and [release-please.yml](.github/workflows/release-please.yml).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29ace4c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->