### PR TITLE
fix(security): prevent XSS via case-insensitive script/style tag injection

### DIFF
--- a/crates/rex_server/src/document.rs
+++ b/crates/rex_server/src/document.rs
@@ -72,7 +72,7 @@ pub fn assemble_document(params: &DocumentParams<'_>) -> String {
     for css in params.css_files {
         if let Some(content) = params.css_contents.get(css) {
             html.push_str("  <style>");
-            html.push_str(content);
+            html.push_str(&escape_style_content(content));
             html.push_str("</style>\n");
         } else {
             // Fallback to link tag if content not available
@@ -136,19 +136,24 @@ pub fn assemble_document(params: &DocumentParams<'_>) -> String {
     html
 }
 
-/// Escape content for safe embedding inside a <script> tag.
-/// Prevents XSS via </script> injection.
+/// Escape content for safe embedding inside a `<script>` tag.
+///
+/// Replaces all `<` with `\u003c` so the HTML parser can never see a closing
+/// `</script>` (or `</SCRIPT>`, `<!--`, etc.) inside the script block.
+/// This is the same approach used by Next.js (`htmlEscapeJsonString`) and
+/// the `serialize-javascript` npm package.
 fn escape_script_content(s: &str) -> String {
-    s.replace("</script", "<\\/script")
-        .replace("<!--", "<\\!--")
+    s.replace('<', "\\u003c")
         .replace('\u{2028}', "\\u2028")
         .replace('\u{2029}', "\\u2029")
 }
 
-/// Escape content for safe embedding inside a <style> tag.
-/// Prevents injection via </style> sequences in CSS content.
+/// Escape content for safe embedding inside a `<style>` tag.
+///
+/// Replaces all `<` so the HTML parser can never see a closing `</style>`
+/// tag (case-insensitive) inside the style block.
 fn escape_style_content(s: &str) -> String {
-    s.replace("</style", "<\\/style")
+    s.replace('<', "\\u003c")
 }
 
 /// Escape a string for use as an HTML attribute value.
@@ -501,178 +506,5 @@ fn extract_body_content(ssr_html: &str) -> &str {
 }
 
 #[cfg(test)]
-#[allow(clippy::unwrap_used)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn escape_script_content_script_tag() {
-        let input = r#"var x = "</script>";"#;
-        let result = escape_script_content(input);
-        assert!(result.contains(r"<\/script"));
-        assert!(!result.contains("</script"));
-    }
-
-    #[test]
-    fn escape_script_content_html_comment() {
-        let input = "<!-- comment -->";
-        let result = escape_script_content(input);
-        assert!(result.contains(r"<\!--"));
-        assert!(!result.contains("<!--"));
-    }
-
-    #[test]
-    fn escape_script_content_line_separators() {
-        let input = "a\u{2028}b\u{2029}c";
-        let result = escape_script_content(input);
-        assert!(result.contains("\\u2028"));
-        assert!(result.contains("\\u2029"));
-        assert!(!result.contains('\u{2028}'));
-        assert!(!result.contains('\u{2029}'));
-    }
-
-    #[test]
-    fn escape_script_content_passthrough() {
-        let input = r#"{"key": "value", "num": 42}"#;
-        let result = escape_script_content(input);
-        assert_eq!(result, input);
-    }
-
-    #[test]
-    fn rsc_head_shell_emits_doctype_and_head() {
-        let chunks = vec!["rsc/chunk-react-abc123.js".to_string()];
-        let manifest = r#"{"refs":{}}"#;
-        let html = assemble_rsc_head_shell(&chunks, manifest, &[], &HashMap::new());
-
-        assert!(html.contains("<!DOCTYPE html>"));
-        assert!(html.contains("<html><head>"));
-        assert!(html.contains("<meta charset=\"utf-8\" />"));
-        assert!(html.contains("</head><body>"));
-        // Module map and webpack shims in the head shell
-        assert!(html.contains("__REX_RSC_MODULE_MAP__"));
-        assert!(html.contains("__rexModuleCache"));
-        // Modulepreload links in the head
-        assert!(html.contains(
-            r#"<link rel="modulepreload" href="/_rex/static/rsc/chunk-react-abc123.js" />"#
-        ));
-    }
-
-    #[test]
-    fn rsc_body_tail_extracts_body_content() {
-        let ssr = "<html><head></head><body><div>Hello</div></body></html>";
-        let html = assemble_rsc_body_tail(
-            ssr,
-            "",
-            "0:\"hello\"\n",
-            &["rsc/component-abc.js".to_string()],
-            "{}",
-            false,
-            None,
-        );
-
-        // Body content extracted from SSR HTML
-        assert!(html.contains("<div>Hello</div>"));
-        // Flight data present
-        assert!(html.contains("__REX_RSC_DATA__"));
-        assert!(html.contains("0:\"hello\""));
-        // Script tags present
-        assert!(html.contains(
-            r#"<script type="module" src="/_rex/static/rsc/component-abc.js"></script>"#
-        ));
-        assert!(html.contains("</body></html>"));
-    }
-
-    #[test]
-    fn rsc_body_tail_fallback_without_html_wrapper() {
-        // SSR HTML without <body> tags: entire string used as body content
-        let ssr = "<div>Hello</div>";
-        let html = assemble_rsc_body_tail(ssr, "", "0:\"hi\"", &[], "{}", false, None);
-
-        // Falls back to using the entire SSR HTML as body content
-        assert!(html.contains("<div>Hello</div>"));
-        assert!(html.contains("</body></html>"));
-    }
-
-    #[test]
-    fn rsc_body_tail_script_ordering() {
-        let ssr = "<html><head></head><body><p>test</p></body></html>";
-        let html = assemble_rsc_body_tail(
-            ssr,
-            "",
-            "0:{}",
-            &["rsc/comp.js".to_string()],
-            "{}",
-            true,
-            Some(r#"{"routes":{}}"#),
-        );
-
-        // Body tail: body content → flight data → route manifest → component scripts → router → HMR
-        let body_content_pos = html.find("<p>test</p>").unwrap();
-        let flight_pos = html.find("__REX_RSC_DATA__").unwrap();
-        let comp_script_pos = html
-            .find(r#"<script type="module" src="/_rex/static/rsc/comp.js">"#)
-            .unwrap();
-        let router_pos = html.find("router.js").unwrap();
-        let hmr_pos = html.find("hmr-client.js").unwrap();
-
-        assert!(body_content_pos < flight_pos);
-        assert!(flight_pos < comp_script_pos);
-        assert!(comp_script_pos < router_pos);
-        assert!(router_pos < hmr_pos);
-    }
-
-    #[test]
-    fn rsc_head_shell_includes_module_map() {
-        let manifest = r#"{"entries":{"abc":{"chunk_url":"/c.js","export_name":"default"}}}"#;
-        let html = assemble_rsc_head_shell(&[], manifest, &[], &HashMap::new());
-
-        assert!(html.contains("__REX_RSC_MODULE_MAP__"));
-        assert!(html.contains("abc"));
-    }
-
-    #[test]
-    fn rsc_head_shell_inlines_css() {
-        let css_files = vec!["globals-abc12345.css".to_string()];
-        let mut css_contents = HashMap::new();
-        css_contents.insert(
-            "globals-abc12345.css".to_string(),
-            "body{margin:0}".to_string(),
-        );
-        let html = assemble_rsc_head_shell(&[], "{}", &css_files, &css_contents);
-
-        assert!(html.contains("<style>body{margin:0}</style>"));
-    }
-
-    #[test]
-    fn rsc_head_shell_falls_back_to_link_tag() {
-        let css_files = vec!["missing.css".to_string()];
-        let html = assemble_rsc_head_shell(&[], "{}", &css_files, &HashMap::new());
-
-        assert!(html.contains(r#"<link rel="stylesheet" href="/_rex/static/missing.css" />"#));
-    }
-
-    #[test]
-    fn rsc_body_tail_includes_metadata_head() {
-        let ssr = "<html><head></head><body><div>Content</div></body></html>";
-        let head_html = r#"<title>My Page</title><meta name="description" content="Test" />"#;
-        let html = assemble_rsc_body_tail(ssr, head_html, "0:{}", &[], "{}", false, None);
-
-        // Metadata head should appear before body content
-        let title_pos = html.find("<title>My Page</title>").unwrap();
-        let content_pos = html.find("<div>Content</div>").unwrap();
-        assert!(
-            title_pos < content_pos,
-            "Metadata head should appear before body content"
-        );
-        assert!(html.contains(r#"<meta name="description" content="Test" />"#));
-    }
-
-    #[test]
-    fn rsc_body_tail_empty_metadata_head() {
-        let ssr = "<html><head></head><body><div>Content</div></body></html>";
-        let html = assemble_rsc_body_tail(ssr, "", "0:{}", &[], "{}", false, None);
-
-        // No metadata head — body content should be first
-        assert!(html.starts_with("<div>Content</div>"));
-    }
-}
+#[path = "document_tests.rs"]
+mod tests;

--- a/crates/rex_server/src/document_tests.rs
+++ b/crates/rex_server/src/document_tests.rs
@@ -1,0 +1,224 @@
+#![allow(clippy::unwrap_used)]
+
+use super::*;
+
+#[test]
+fn escape_script_content_script_tag() {
+    let input = r#"var x = "</script>";"#;
+    let result = escape_script_content(input);
+    assert!(!result.contains("</script"));
+    assert!(!result.contains('<'));
+}
+
+#[test]
+fn escape_script_content_case_insensitive() {
+    // HTML parsers match end tags case-insensitively, so </SCRIPT> and
+    // </Script> must also be neutralized.
+    for tag in ["</SCRIPT>", "</Script>", "</sCrIpT>"] {
+        let input = format!(r#"{{"x": "{tag}"}}"#);
+        let result = escape_script_content(&input);
+        assert!(
+            !result.contains('<'),
+            "escape_script_content must neutralize {tag}"
+        );
+    }
+}
+
+#[test]
+fn escape_script_content_html_comment() {
+    let input = "<!-- comment -->";
+    let result = escape_script_content(input);
+    assert!(!result.contains("<!--"));
+    assert!(!result.contains('<'));
+}
+
+#[test]
+fn escape_script_content_line_separators() {
+    let input = "a\u{2028}b\u{2029}c";
+    let result = escape_script_content(input);
+    assert!(result.contains("\\u2028"));
+    assert!(result.contains("\\u2029"));
+    assert!(!result.contains('\u{2028}'));
+    assert!(!result.contains('\u{2029}'));
+}
+
+#[test]
+fn escape_script_content_passthrough() {
+    let input = r#"{"key": "value", "num": 42}"#;
+    let result = escape_script_content(input);
+    assert_eq!(result, input);
+}
+
+#[test]
+fn escape_style_content_case_insensitive() {
+    for tag in ["</style>", "</STYLE>", "</Style>"] {
+        let input = format!("body{{}} {tag}");
+        let result = escape_style_content(&input);
+        assert!(
+            !result.contains('<'),
+            "escape_style_content must neutralize {tag}"
+        );
+    }
+}
+
+#[test]
+fn assemble_document_escapes_inline_css() {
+    let mut css_contents = HashMap::new();
+    css_contents.insert(
+        "test.css".to_string(),
+        "body{} </style><script>alert(1)</script>".to_string(),
+    );
+    let params = DocumentParams {
+        ssr_html: "<div>hi</div>",
+        head_html: "",
+        props_json: "{}",
+        client_scripts: &[],
+        css_files: &["test.css".to_string()],
+        css_contents: &css_contents,
+        app_script: None,
+        is_dev: false,
+        doc_descriptor: None,
+        manifest_json: None,
+        font_preloads: &[],
+    };
+    let html = assemble_document(&params);
+    // The </style> inside the CSS must be escaped so the style block isn't closed prematurely
+    assert!(!html.contains("</style><script>"));
+}
+
+#[test]
+fn rsc_head_shell_emits_doctype_and_head() {
+    let chunks = vec!["rsc/chunk-react-abc123.js".to_string()];
+    let manifest = r#"{"refs":{}}"#;
+    let html = assemble_rsc_head_shell(&chunks, manifest, &[], &HashMap::new());
+
+    assert!(html.contains("<!DOCTYPE html>"));
+    assert!(html.contains("<html><head>"));
+    assert!(html.contains("<meta charset=\"utf-8\" />"));
+    assert!(html.contains("</head><body>"));
+    // Module map and webpack shims in the head shell
+    assert!(html.contains("__REX_RSC_MODULE_MAP__"));
+    assert!(html.contains("__rexModuleCache"));
+    // Modulepreload links in the head
+    assert!(html
+        .contains(r#"<link rel="modulepreload" href="/_rex/static/rsc/chunk-react-abc123.js" />"#));
+}
+
+#[test]
+fn rsc_body_tail_extracts_body_content() {
+    let ssr = "<html><head></head><body><div>Hello</div></body></html>";
+    let html = assemble_rsc_body_tail(
+        ssr,
+        "",
+        "0:\"hello\"\n",
+        &["rsc/component-abc.js".to_string()],
+        "{}",
+        false,
+        None,
+    );
+
+    // Body content extracted from SSR HTML
+    assert!(html.contains("<div>Hello</div>"));
+    // Flight data present
+    assert!(html.contains("__REX_RSC_DATA__"));
+    assert!(html.contains("0:\"hello\""));
+    // Script tags present
+    assert!(
+        html.contains(r#"<script type="module" src="/_rex/static/rsc/component-abc.js"></script>"#)
+    );
+    assert!(html.contains("</body></html>"));
+}
+
+#[test]
+fn rsc_body_tail_fallback_without_html_wrapper() {
+    // SSR HTML without <body> tags: entire string used as body content
+    let ssr = "<div>Hello</div>";
+    let html = assemble_rsc_body_tail(ssr, "", "0:\"hi\"", &[], "{}", false, None);
+
+    // Falls back to using the entire SSR HTML as body content
+    assert!(html.contains("<div>Hello</div>"));
+    assert!(html.contains("</body></html>"));
+}
+
+#[test]
+fn rsc_body_tail_script_ordering() {
+    let ssr = "<html><head></head><body><p>test</p></body></html>";
+    let html = assemble_rsc_body_tail(
+        ssr,
+        "",
+        "0:{}",
+        &["rsc/comp.js".to_string()],
+        "{}",
+        true,
+        Some(r#"{"routes":{}}"#),
+    );
+
+    // Body tail: body content → flight data → route manifest → component scripts → router → HMR
+    let body_content_pos = html.find("<p>test</p>").unwrap();
+    let flight_pos = html.find("__REX_RSC_DATA__").unwrap();
+    let comp_script_pos = html
+        .find(r#"<script type="module" src="/_rex/static/rsc/comp.js">"#)
+        .unwrap();
+    let router_pos = html.find("router.js").unwrap();
+    let hmr_pos = html.find("hmr-client.js").unwrap();
+
+    assert!(body_content_pos < flight_pos);
+    assert!(flight_pos < comp_script_pos);
+    assert!(comp_script_pos < router_pos);
+    assert!(router_pos < hmr_pos);
+}
+
+#[test]
+fn rsc_head_shell_includes_module_map() {
+    let manifest = r#"{"entries":{"abc":{"chunk_url":"/c.js","export_name":"default"}}}"#;
+    let html = assemble_rsc_head_shell(&[], manifest, &[], &HashMap::new());
+
+    assert!(html.contains("__REX_RSC_MODULE_MAP__"));
+    assert!(html.contains("abc"));
+}
+
+#[test]
+fn rsc_head_shell_inlines_css() {
+    let css_files = vec!["globals-abc12345.css".to_string()];
+    let mut css_contents = HashMap::new();
+    css_contents.insert(
+        "globals-abc12345.css".to_string(),
+        "body{margin:0}".to_string(),
+    );
+    let html = assemble_rsc_head_shell(&[], "{}", &css_files, &css_contents);
+
+    assert!(html.contains("<style>body{margin:0}</style>"));
+}
+
+#[test]
+fn rsc_head_shell_falls_back_to_link_tag() {
+    let css_files = vec!["missing.css".to_string()];
+    let html = assemble_rsc_head_shell(&[], "{}", &css_files, &HashMap::new());
+
+    assert!(html.contains(r#"<link rel="stylesheet" href="/_rex/static/missing.css" />"#));
+}
+
+#[test]
+fn rsc_body_tail_includes_metadata_head() {
+    let ssr = "<html><head></head><body><div>Content</div></body></html>";
+    let head_html = r#"<title>My Page</title><meta name="description" content="Test" />"#;
+    let html = assemble_rsc_body_tail(ssr, head_html, "0:{}", &[], "{}", false, None);
+
+    // Metadata head should appear before body content
+    let title_pos = html.find("<title>My Page</title>").unwrap();
+    let content_pos = html.find("<div>Content</div>").unwrap();
+    assert!(
+        title_pos < content_pos,
+        "Metadata head should appear before body content"
+    );
+    assert!(html.contains(r#"<meta name="description" content="Test" />"#));
+}
+
+#[test]
+fn rsc_body_tail_empty_metadata_head() {
+    let ssr = "<html><head></head><body><div>Content</div></body></html>";
+    let html = assemble_rsc_body_tail(ssr, "", "0:{}", &[], "{}", false, None);
+
+    // No metadata head — body content should be first
+    assert!(html.starts_with("<div>Content</div>"));
+}


### PR DESCRIPTION
## Summary

- **Fix case-insensitive `</script>` XSS bypass**: `escape_script_content` used a case-sensitive `replace("</script", ...)` but HTML parsers match end tags case-insensitively. Payloads like `</SCRIPT>` or `</Script>` could break out of inline `<script>` blocks when user-controlled data was reflected via `getServerSideProps`. Now replaces all `<` with `\u003c` (same approach as Next.js `htmlEscapeJsonString`).
- **Fix same bypass in `escape_style_content`**: `</STYLE>` could close inline `<style>` tags.
- **Fix missing CSS escaping in `assemble_document`**: the non-streaming path inlined CSS without calling `escape_style_content`, while the streaming path (`assemble_head_shell`) did escape.
- Extract document tests to `document_tests.rs` to stay under 700-line limit.

## Test plan

- [x] New test: `escape_script_content_case_insensitive` — verifies `</SCRIPT>`, `</Script>`, `</sCrIpT>` are all neutralized
- [x] New test: `escape_style_content_case_insensitive` — verifies `</STYLE>`, `</Style>` are neutralized
- [x] New test: `assemble_document_escapes_inline_css` — verifies CSS with `</style><script>alert(1)</script>` is escaped in the non-streaming path
- [x] All 16 document tests pass
- [x] All 29 E2E tests pass
- [x] `cargo clippy` clean, `cargo check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix XSS by escaping all `<` characters in inline `<script>` and `<style>` tag content
> - `escape_script_content` now replaces all `<` with `\u003c` instead of only targeting `</script` and `<!--`, preventing case-insensitive tag injection.
> - `escape_style_content` applies the same broad `<` escaping instead of only targeting `</style`.
> - `assemble_document` in [document.rs](https://github.com/limlabs/rex/pull/156/files#diff-5e7f033a2cc125d93db8b22cde329cd9225b7f4be58e650fa25bb5aa3e56c859) now calls `escape_style_content` when inlining CSS, which was previously unescaped.
> - Tests are moved to an external [document_tests.rs](https://github.com/limlabs/rex/pull/156/files#diff-046e28f1aa899d2e7cca06d5bb33730b2d87331c9d58f6b65c44f96c5e3e68bd) and extended to cover case-insensitive tag neutralization.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7ef8132. 1 file reviewed, 2 issues evaluated, 1 issue filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> <details>
> <summary>crates/rex_server/src/document.rs — 0 comments posted, 2 evaluated, 1 filtered</summary>
>
> - [line 75](https://github.com/limlabs/rex/blob/7ef81328ebeaf40bbdbf76d45e5c86da830787a7/crates/rex_server/src/document.rs#L75): The `escape_style_content` function replaces `<` with `\u003c`, but `\u003c` is a JavaScript/JSON escape sequence, not a valid CSS escape sequence. In CSS, `\uNNNN` is not recognized - CSS escapes use `\HHHHHH` (backslash followed by 1-6 hex digits). When CSS content contains `<` (e.g., `content: "<";`), it will be corrupted: `\u003c` is parsed by CSS as the escaped character 'u' (`\u`) followed by literal text "003c", resulting in the string "u003c" instead of `<`. The correct CSS escape would be `\3c ` (with trailing whitespace) or `\00003c`. <b>[ Out of scope ]</b>
> </details>
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->