### PR TITLE
chore: separate internal workflow from public CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,48 +1,5 @@
 # Rex — Development Guide for Claude
 
-## Worktree Workflow
-
-**ALWAYS use a git worktree when making any changes.** Never create branches or make commits directly on the current worktree.
-
-1. At the start of any task that involves code changes, use the `EnterWorktree` tool to create an isolated worktree.
-2. All edits, commits, and pushes must happen inside the worktree — never on the main checkout.
-3. After finishing, create a PR from the worktree branch.
-
-## Git Identity
-
-At the start of every session, configure the bot identity for commits and pushes. The PAT is stored in 1Password and read via the `op` CLI.
-
-**IMPORTANT: Never embed the PAT value directly in commands or git config.** The token must only live in a credentials file to prevent it from leaking into chat output.
-
-```bash
-# Step 1: Read PAT and write to a credentials file (single command to avoid leaking the value)
-op read 'op://claude/ClaudeLiminal-GitHub/pat' | xargs -I{} sh -c 'echo "https://x-access-token:{}@github.com" > "$HOME/.rex-git-credentials" && chmod 600 "$HOME/.rex-git-credentials"'
-
-# Step 2: Configure git to use the file-based credential store
-git config --local credential.helper "store --file=$HOME/.rex-git-credentials"
-
-# Step 3: Export GH_TOKEN for gh CLI (read from the credentials file)
-export GH_TOKEN="$(sed -n 's|https://x-access-token:\(.*\)@github.com|\1|p' "$HOME/.rex-git-credentials")"
-```
-
-If `op` is not available or fails, warn the user and continue without bot identity. Do not commit or push until the identity is configured.
-
-When committing, always use the bot author:
-
-```bash
-git commit --author="claude-liminal <264858718+claude-liminal@users.noreply.github.com>"
-```
-
-When using `gh` CLI (PRs, issues), pass `GH_TOKEN`:
-
-```bash
-GH_TOKEN="$GH_TOKEN" gh pr create ...
-```
-
-## GitHub Operations
-
-**Prefer MCP tools (`mcp__github__*`) over `gh` CLI** for PRs, issues, and reviews. Use `gh` CLI only for operations not covered by MCP (e.g., pushing code, release creation).
-
 ## Conventional Commits
 
 All commits must use [Conventional Commits](https://www.conventionalcommits.org/) — enforced by a `commit-msg` hook and required by release-please for changelog/version bumps:
@@ -223,29 +180,3 @@ docker run -v $(pwd):/app -w /app -p 3000:3000 rex
 | `GITHUB_TOKEN` | Automatic | GHCR push, release asset upload |
 | `NPM_TOKEN` | Manual (`gh secret set NPM_TOKEN`) | npm publish |
 | `CARGO_REGISTRY_TOKEN` | Manual (`gh secret set CARGO_REGISTRY_TOKEN`) | crates.io publish |
-
-## Plane Project Tracker
-
-Project **Rex** (`REX`), ID: `bb7d9e34-d888-4548-bdec-016b8e01a12f`
-
-### IDs to avoid re-fetching
-
-| Entity | ID |
-|--------|----|
-| **Project** | `bb7d9e34-d888-4548-bdec-016b8e01a12f` |
-| **State: Backlog** | `cb79eadb-59c3-42c8-b00c-9c6dd2afb92d` |
-| **State: Todo** | `9a2c6253-2c12-4f08-93ca-85c9b8188402` |
-| **State: In Progress** | `11b53ad5-e64c-46f0-b311-e24ecc102c08` |
-| **State: Done** | `0c34df63-44e3-4c15-b385-8ad59a69dd71` |
-| **State: Cancelled** | `f30c0c05-121d-4220-9e9c-402f64807212` |
-| **Label: bugfix** | `4213c893-0f4f-4f6d-bf74-b16028078c10` |
-| **Label: architecture** | `2df292a3-cc91-4ad0-a331-fa33200a9636` |
-| **Label: testing** | `e702cf96-599a-4470-947a-5cc4eb215b5b` |
-| **Label: feature** | `b4cdf3c7-3e11-4322-8828-8d33d3fb5d1d` |
-
-### Usage tips
-
-- Use IDs directly from the table above — no need to call `list_states` or `list_labels`
-- To mark a work item done: `update_work_item(state: "0c34df63-...")`
-- Search work items by name with `search_work_items` instead of listing all
-- When creating work items, set `priority` (urgent/high/medium/low/none) and `point` (effort)


### PR DESCRIPTION
## Summary

- Removes team-specific workflow instructions from the checked-in `CLAUDE.md` so public agents and external contributors aren't confused by internal processes
- Moved to `.claude/CLAUDE.md` (gitignored) — Claude Code still loads it locally for team members: worktree policy, 1Password PAT/bot identity setup, MCP tool preferences, Plane project tracker IDs
- The public `CLAUDE.md` now contains only universal project rules: conventional commits, testing (all 4 layers), 700-line rule, crate map, architecture patterns, CI/CD

## Test plan

- [ ] Verify `CLAUDE.md` reads correctly as a public contributor guide
- [ ] Verify `.claude/CLAUDE.md` exists locally with internal workflow instructions
- [ ] Confirm `.claude/CLAUDE.md` is NOT included in the PR diff (gitignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove internal workflow sections from public CLAUDE.md
> Strips internal-only content from [CLAUDE.md](https://github.com/limlabs/rex/pull/160/files#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7), including the Worktree Workflow, Git Identity (1Password/op, GH_TOKEN, gh CLI), GitHub Operations, and Plane Project Tracker sections. The remaining content covers Conventional Commits and required secrets.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bbb5251.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->