### PR TITLE
fix(init): true zero-config init — no package.json or npm required

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Reproduce: `cd benchmarks && uv run python bench.py --suite dx,server --framewor
 ```sh
 npx @limlabs/rex init my-app
 cd my-app
-npm install
-npx rex dev
+rex dev
 ```
 
 Open http://localhost:3000.

--- a/crates/rex_cli/src/main.rs
+++ b/crates/rex_cli/src/main.rs
@@ -545,54 +545,10 @@ fn cmd_init(name: String) -> Result<()> {
     eprintln!("  {} {}", magenta_bold("◆ rex"), dim("creating project..."));
     eprintln!();
 
-    // Create directory structure
-    std::fs::create_dir_all(project_dir.join("pages/api"))?;
-    std::fs::create_dir_all(project_dir.join("styles"))?;
+    // Create directory structure — no package.json needed.
+    // Rex embeds React and extracts it automatically on first run.
+    std::fs::create_dir_all(project_dir.join("pages"))?;
     std::fs::create_dir_all(project_dir.join("public"))?;
-
-    // package.json
-    std::fs::write(
-        project_dir.join("package.json"),
-        format!(
-            r#"{{
-  "name": "{name}",
-  "version": "0.1.0",
-  "private": true,
-  "dependencies": {{
-    "react": "^19.0.0",
-    "react-dom": "^19.0.0"
-  }},
-  "devDependencies": {{
-    "@types/react": "^19.0.0",
-    "@types/react-dom": "^19.0.0"
-  }}
-}}
-"#
-        ),
-    )?;
-
-    // tsconfig.json
-    std::fs::write(
-        project_dir.join("tsconfig.json"),
-        r#"{
-  "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
-    "jsx": "react-jsx",
-    "strict": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true,
-    "resolveJsonModule": true,
-    "isolatedModules": true,
-    "noEmit": true
-  },
-  "include": ["pages/**/*"],
-  "exclude": ["node_modules", ".rex"]
-}
-"#,
-    )?;
 
     // .gitignore
     std::fs::write(
@@ -622,50 +578,12 @@ export async function getServerSideProps() {
 "#,
     )?;
 
-    // pages/_app.tsx
-    std::fs::write(
-        project_dir.join("pages/_app.tsx"),
-        r#"import '../styles/globals.css';
-
-export default function App({ Component, pageProps }: { Component: any; pageProps: any }) {
-  return <Component {...pageProps} />;
-}
-"#,
-    )?;
-
-    // pages/api/hello.ts
-    std::fs::write(
-        project_dir.join("pages/api/hello.ts"),
-        r#"export default function handler(req: any, res: any) {
-  res.status(200).json({ message: "Hello from Rex API!" });
-}
-"#,
-    )?;
-
-    // styles/globals.css
-    std::fs::write(
-        project_dir.join("styles/globals.css"),
-        r#"*,
-*::before,
-*::after {
-  box-sizing: border-box;
-  margin: 0;
-  padding: 0;
-}
-
-body {
-  font-family: system-ui, -apple-system, sans-serif;
-  -webkit-font-smoothing: antialiased;
-}
-
-a {
-  color: inherit;
-  text-decoration: none;
-}
-"#,
-    )?;
-
     eprintln!("  {} {}", green_bold("✓"), green_bold("Project created"));
+    eprintln!();
+    eprintln!("  {}", dim("Get started:"));
+    eprintln!();
+    eprintln!("    {} {}", bold("cd"), bold(&name));
+    eprintln!("    {} {}", bold("rex dev"), dim(""));
     eprintln!();
 
     Ok(())

--- a/docs/app/getting-started/installation/page.mdx
+++ b/docs/app/getting-started/installation/page.mdx
@@ -21,8 +21,9 @@ This installs the Rex CLI and runtime. The CLI binary is platform-specific and d
 
 ### Prerequisites
 
-- **Node.js 18+** — required for `npm install` and fixture setup
-- **React 18 or 19** — React 19 is recommended for Server Components support; React 18 works for Pages Router
+- **Node.js 18+** — required only for the initial `npx @limlabs/rex init` (or `npm install -g @limlabs/rex`). Not needed at runtime.
+
+Rex embeds React 19 and extracts it automatically — no `npm install` or `package.json` required for zero-config projects. Add a `package.json` when you need a lockfile or extra dependencies.
 
 ## Docker
 

--- a/docs/app/getting-started/page.mdx
+++ b/docs/app/getting-started/page.mdx
@@ -1,32 +1,29 @@
 # Quickstart
 
-Get a Rex app running in under a minute.
+Get a Rex app running in under a minute. No `package.json` or `npm install` required — Rex embeds React and extracts it automatically.
 
 ## Create a new project
-
-The fastest way to start is with `rex init`:
 
 ```bash
 npx @limlabs/rex init my-app
 cd my-app
-npm install
+rex dev
 ```
 
-Or set up manually:
+That's it. Rex scaffolds a starter page, installs itself globally, and the dev server handles the rest.
+
+## Start from scratch
+
+You can also create a project by hand — just add a page:
 
 ```bash
 mkdir my-app && cd my-app
-npm init -y
-npm install @limlabs/rex react react-dom
+mkdir pages
 ```
-
-## Add your first page
 
 Create `pages/index.tsx`:
 
 ```tsx
-import React from "react";
-
 export default function Home() {
   return (
     <div>
@@ -40,7 +37,7 @@ export default function Home() {
 ## Start the dev server
 
 ```bash
-npx rex dev
+rex dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) to see your page.

--- a/packages/rex/bin/rex.js
+++ b/packages/rex/bin/rex.js
@@ -47,11 +47,6 @@ function getBinaryPath() {
   }
 }
 
-// ANSI helpers (matching Rust display helpers)
-const bold = (s) => `\x1b[1m${s}\x1b[0m`;
-const dim = (s) => `\x1b[2m${s}\x1b[0m`;
-const greenBold = (s) => `\x1b[1;32m${s}\x1b[0m`;
-
 function isRexGloballyInstalled() {
   try {
     execSync("rex --version", { stdio: "ignore" });
@@ -74,46 +69,22 @@ try {
   throw e;
 }
 
-// Post-init: install dependencies, ensure rex is globally available, print instructions
-if (isInit && args.length >= 2) {
-  const projectName = args[1];
-  const projectDir = path.resolve(projectName);
+// After init, install rex globally if not already available so `rex dev` works
+if (isInit && !isRexGloballyInstalled()) {
+  const dim = (s) => `\x1b[2m${s}\x1b[0m`;
+  const greenBold = (s) => `\x1b[1;32m${s}\x1b[0m`;
 
-  // Install project dependencies (react, react-dom)
-  process.stderr.write(`  Installing dependencies...\n\n`);
+  process.stderr.write(`  Installing rex globally...\n\n`);
   try {
-    execSync("npm install --silent", {
-      cwd: projectDir,
+    execSync("npm install -g @limlabs/rex", {
       stdio: ["ignore", "ignore", "inherit"],
     });
     process.stderr.write(
-      `  ${greenBold("✓")} ${greenBold("Dependencies installed")}\n\n`
+      `  ${greenBold("✓")} ${greenBold("Rex installed globally")}\n\n`
     );
   } catch {
     process.stderr.write(
-      `  ${dim("Could not install dependencies. Run 'npm install' in the project directory.")}\n\n`
+      `  ${dim("Could not install rex globally. Run 'npm install -g @limlabs/rex' manually.")}\n\n`
     );
   }
-
-  // Install rex globally if not already available
-  if (!isRexGloballyInstalled()) {
-    process.stderr.write(`  Installing rex globally...\n\n`);
-    try {
-      execSync("npm install -g @limlabs/rex", {
-        stdio: ["ignore", "ignore", "inherit"],
-      });
-      process.stderr.write(
-        `  ${greenBold("✓")} ${greenBold("Rex installed globally")}\n\n`
-      );
-    } catch {
-      process.stderr.write(
-        `  ${dim("Could not install rex globally. Run 'npm install -g @limlabs/rex' manually.")}\n\n`
-      );
-    }
-  }
-
-  // Print get started instructions (zero-config: no npm commands)
-  process.stderr.write(`  ${dim("Get started:")}\n\n`);
-  process.stderr.write(`    ${bold("cd")} ${bold(projectName)}\n`);
-  process.stderr.write(`    ${bold("rex dev")}\n\n`);
 }


### PR DESCRIPTION
## Summary
- `rex init` now creates a truly zero-config project: just `pages/index.tsx`, `public/`, and `.gitignore`
- No `package.json`, `tsconfig.json`, `_app.tsx`, API routes, or CSS boilerplate — Rex embeds React and extracts it automatically on first `rex dev`
- The JS shim installs rex globally after init so `rex dev` works immediately (no `npx` needed)
- Updated README and docs quickstart to match the zero-config flow

## Next steps
A follow-up PR will add an npm-free install path (`curl -fsSL ... | sh`) so the entire workflow works without Node.

## Test plan
- [x] `npx @limlabs/rex init my-app` creates minimal project (no package.json)
- [x] All pre-commit hooks pass (check, clippy, fmt, oxlint, typecheck)
- [x] All 29 E2E tests pass
- [ ] Verify `rex dev` works in the scaffolded project (builtin React extraction)
- [ ] Verify on clean machine without rex installed globally