### PR TITLE
feat(install): curl-pipe install script for npm-free setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ Reproduce: `cd benchmarks && uv run python bench.py --suite dx,server --framewor
 ## Quick Start
 
 ```sh
-npx @limlabs/rex init my-app
+curl -fsSL https://raw.githubusercontent.com/limlabs/rex/main/install.sh | sh
+rex init my-app
 cd my-app
 rex dev
 ```
@@ -41,13 +42,21 @@ Open http://localhost:3000.
 
 ## Install
 
-### npm (recommended)
+### Shell (recommended)
 
 ```sh
-npm install -D @limlabs/rex
+curl -fsSL https://raw.githubusercontent.com/limlabs/rex/main/install.sh | sh
 ```
 
-Installs the `rex` binary for your platform (macOS arm64/x64, Linux x64/arm64).
+Downloads the latest binary for your platform (macOS arm64/x64, Linux x64/arm64) to `~/.rex/bin`.
+
+### npm
+
+```sh
+npx @limlabs/rex init my-app    # one-shot, no global install
+# or
+npm install -g @limlabs/rex      # global install
+```
 
 ### From source
 

--- a/docs/app/getting-started/installation/page.mdx
+++ b/docs/app/getting-started/installation/page.mdx
@@ -1,14 +1,18 @@
 # Installation
 
-## npm
-
-The recommended way to install Rex:
+## Shell (recommended)
 
 ```bash
-npm install @limlabs/rex
+curl -fsSL https://raw.githubusercontent.com/limlabs/rex/main/install.sh | sh
 ```
 
-This installs the Rex CLI and runtime. The CLI binary is platform-specific and downloaded automatically for your OS and architecture.
+Downloads the latest binary for your platform to `~/.rex/bin` and adds it to your PATH. No Node.js required.
+
+To install a specific version:
+
+```bash
+REX_VERSION=0.15.2 curl -fsSL https://raw.githubusercontent.com/limlabs/rex/main/install.sh | sh
+```
 
 ### Supported platforms
 
@@ -21,9 +25,21 @@ This installs the Rex CLI and runtime. The CLI binary is platform-specific and d
 
 ### Prerequisites
 
-- **Node.js 18+** — required only for the initial `npx @limlabs/rex init` (or `npm install -g @limlabs/rex`). Not needed at runtime.
+None. Rex is a single binary with React embedded. No Node.js, no `npm install`, no `package.json` needed for zero-config projects. Add a `package.json` when you need a lockfile or extra dependencies.
 
-Rex embeds React 19 and extracts it automatically — no `npm install` or `package.json` required for zero-config projects. Add a `package.json` when you need a lockfile or extra dependencies.
+## npm
+
+If you prefer npm:
+
+```bash
+npm install -g @limlabs/rex
+```
+
+Or use `npx` for one-shot commands without a global install:
+
+```bash
+npx @limlabs/rex init my-app
+```
 
 ## Docker
 
@@ -38,8 +54,6 @@ Or use the Dockerfile included in your project:
 ```dockerfile
 FROM ghcr.io/limlabs/rex:latest
 WORKDIR /app
-COPY package*.json ./
-RUN npm install
 COPY . .
 RUN rex build
 CMD ["rex", "start"]
@@ -62,5 +76,5 @@ The binary is built to `target/release/rex`. You'll need Rust 1.75+ and a C++ co
 ## Verify installation
 
 ```bash
-npx rex --version
+rex --version
 ```

--- a/docs/app/getting-started/page.mdx
+++ b/docs/app/getting-started/page.mdx
@@ -2,15 +2,23 @@
 
 Get a Rex app running in under a minute. No `package.json` or `npm install` required — Rex embeds React and extracts it automatically.
 
+## Install Rex
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/limlabs/rex/main/install.sh | sh
+```
+
+Or via npm: `npx @limlabs/rex init my-app` (one-shot, no global install needed).
+
 ## Create a new project
 
 ```bash
-npx @limlabs/rex init my-app
+rex init my-app
 cd my-app
 rex dev
 ```
 
-That's it. Rex scaffolds a starter page, installs itself globally, and the dev server handles the rest.
+That's it. Rex scaffolds a starter page and the dev server handles the rest.
 
 ## Start from scratch
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,162 @@
+#!/bin/sh
+# Rex installer — downloads the latest release binary from GitHub.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/limlabs/rex/main/install.sh | sh
+#
+# Options (environment variables):
+#   REX_VERSION   Install a specific version (e.g. "0.15.2"). Default: latest.
+#   REX_INSTALL   Installation directory. Default: ~/.rex/bin
+
+set -eu
+
+REPO="limlabs/rex"
+INSTALL_DIR="${REX_INSTALL:-$HOME/.rex/bin}"
+
+# --- Helpers ---
+
+info() { printf '  \033[1;35m%s\033[0m %s\n' "◆" "$1"; }
+ok()   { printf '  \033[1;32m✓\033[0m \033[1;32m%s\033[0m\n' "$1"; }
+err()  { printf '  \033[1;31m✗\033[0m %s\n' "$1" >&2; exit 1; }
+dim()  { printf '  \033[2m%s\033[0m\n' "$1"; }
+bold() { printf '  \033[1m%s\033[0m\n' "$1"; }
+
+# --- Detect platform ---
+
+detect_platform() {
+  OS="$(uname -s)"
+  ARCH="$(uname -m)"
+
+  case "$OS" in
+    Darwin) OS="macos" ;;
+    Linux)  OS="linux" ;;
+    *)      err "Unsupported OS: $OS" ;;
+  esac
+
+  case "$ARCH" in
+    x86_64|amd64)  ARCH="x86_64" ;;
+    aarch64|arm64) ARCH="arm64" ;;
+    *)             err "Unsupported architecture: $ARCH" ;;
+  esac
+
+  PLATFORM="${OS}-${ARCH}"
+}
+
+# --- Resolve version ---
+
+resolve_version() {
+  if [ -n "${REX_VERSION:-}" ]; then
+    VERSION="$REX_VERSION"
+    return
+  fi
+
+  # Fetch latest release tag from GitHub API
+  if command -v curl >/dev/null 2>&1; then
+    VERSION="$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/')"
+  elif command -v wget >/dev/null 2>&1; then
+    VERSION="$(wget -qO- "https://api.github.com/repos/${REPO}/releases/latest" | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"v\{0,1\}\([^"]*\)".*/\1/')"
+  else
+    err "curl or wget is required"
+  fi
+
+  if [ -z "$VERSION" ]; then
+    err "Could not determine latest version"
+  fi
+}
+
+# --- Download and install ---
+
+download() {
+  TARBALL="rex-${PLATFORM}.tar.gz"
+  URL="https://github.com/${REPO}/releases/download/v${VERSION}/${TARBALL}"
+
+  TMPDIR="$(mktemp -d)"
+  trap 'rm -rf "$TMPDIR"' EXIT
+
+  info "Downloading rex v${VERSION} for ${PLATFORM}..."
+  echo
+
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$URL" -o "${TMPDIR}/${TARBALL}" || err "Download failed. Check that v${VERSION} has a binary for ${PLATFORM}."
+  elif command -v wget >/dev/null 2>&1; then
+    wget -q "$URL" -O "${TMPDIR}/${TARBALL}" || err "Download failed. Check that v${VERSION} has a binary for ${PLATFORM}."
+  fi
+
+  # Extract
+  tar xzf "${TMPDIR}/${TARBALL}" -C "$TMPDIR"
+
+  # Install
+  mkdir -p "$INSTALL_DIR"
+  mv "${TMPDIR}/rex" "${INSTALL_DIR}/rex"
+  chmod +x "${INSTALL_DIR}/rex"
+}
+
+# --- Shell profile detection ---
+
+add_to_path() {
+  # Check if already on PATH
+  case ":$PATH:" in
+    *":${INSTALL_DIR}:"*) return ;;
+  esac
+
+  SHELL_NAME="$(basename "${SHELL:-/bin/sh}")"
+  case "$SHELL_NAME" in
+    zsh)  PROFILE="$HOME/.zshrc" ;;
+    bash)
+      if [ -f "$HOME/.bashrc" ]; then
+        PROFILE="$HOME/.bashrc"
+      else
+        PROFILE="$HOME/.bash_profile"
+      fi
+      ;;
+    fish) PROFILE="$HOME/.config/fish/config.fish" ;;
+    *)    PROFILE="$HOME/.profile" ;;
+  esac
+
+  LINE="export PATH=\"${INSTALL_DIR}:\$PATH\""
+  if [ "$SHELL_NAME" = "fish" ]; then
+    LINE="set -gx PATH ${INSTALL_DIR} \$PATH"
+  fi
+
+  if [ -f "$PROFILE" ] && grep -qF "$INSTALL_DIR" "$PROFILE" 2>/dev/null; then
+    return
+  fi
+
+  echo >> "$PROFILE"
+  echo "# Rex" >> "$PROFILE"
+  echo "$LINE" >> "$PROFILE"
+
+  ADDED_TO_PROFILE=1
+}
+
+# --- Main ---
+
+main() {
+  echo
+  detect_platform
+  resolve_version
+  download
+
+  ok "Rex v${VERSION} installed to ${INSTALL_DIR}/rex"
+  echo
+
+  ADDED_TO_PROFILE=0
+  add_to_path
+
+  if [ "$ADDED_TO_PROFILE" = "1" ]; then
+    dim "Added ${INSTALL_DIR} to PATH in ${PROFILE}"
+    dim "Restart your shell or run:"
+    echo
+    bold "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+    echo
+  fi
+
+  dim "Get started:"
+  echo
+  bold "  rex init my-app"
+  bold "  cd my-app"
+  bold "  rex dev"
+  echo
+}
+
+main


### PR DESCRIPTION
## Summary
Adds `install.sh` — a curl-pipe installer that downloads the Rex binary from GitHub releases with zero npm/Node dependency.

```bash
curl -fsSL https://raw.githubusercontent.com/limlabs/rex/main/install.sh | sh
rex init my-app
cd my-app
rex dev
```

- Detects platform (macOS/Linux, x64/arm64) and downloads the matching tarball from GitHub releases
- Installs to `~/.rex/bin` (configurable via `REX_INSTALL` env var)
- Adds to PATH via shell profile detection (zsh/bash/fish)
- Supports version pinning via `REX_VERSION` env var
- Updates README and docs to show shell installer as primary, npm as alternative

Stacked on #172 (zero-config init).

## Test plan
- [x] Platform detection verified locally (macOS arm64 -> `rex-macos-arm64.tar.gz`)
- [x] Version resolution from GitHub API verified (`v0.15.2`)
- [x] Download URL format matches release workflow asset names
- [x] All pre-commit hooks pass
- [x] All 29 E2E tests pass
- [ ] Full end-to-end test on clean machine

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add curl-pipe install script for npm-free Rex setup
> - Adds [install.sh](https://github.com/limlabs/rex/pull/174/files#diff-043df5bdbf6639d7a77e1d44c5226fd7371e5259a1e4df3a0dd5d64c30dca44f) that detects OS/arch, fetches the latest (or pinned) release from GitHub, installs the `rex` binary to `~/.rex/bin`, and updates the user's shell profile PATH.
> - `rex init` no longer scaffolds `package.json`, `tsconfig.json`, API routes, or styles, and drops the `npm install` post-init step since React is now embedded in the binary.
> - After `npx @limlabs/rex init`, [rex.js](https://github.com/limlabs/rex/pull/174/files#diff-3ad0d38f0f445a8fed9b0cd166c424a4017e9135e1380eb8007d7d6f7e4ca346) attempts a global `npm install -g @limlabs/rex` automatically if `rex` is not already on PATH, so subsequent `rex dev` works without `npx`.
> - README and docs are updated to lead with the shell installer and move npm usage to a secondary section.
> - Behavioral Change: `rex init` produces a slimmer project skeleton; existing guides that reference `npm install` after `rex init` are now outdated.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c5b778.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->