### PR TITLE
fix(ci): remove stale lockfile and avoid npx in smoke tests

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -30,6 +30,8 @@ jobs:
         run: |
           VERSION="${INPUT_VERSION#v}"
           cd "fixtures/${{ matrix.fixture }}"
+          # Remove lockfile so npm resolves from registry, not stale file: references
+          rm -f package-lock.json
           node -e "
             const fs = require('fs');
             const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
@@ -66,21 +68,24 @@ jobs:
 
       - name: Install dependencies
         run: |
+          VERSION="${INPUT_VERSION#v}"
           cd "fixtures/${{ matrix.fixture }}"
           npm install
           # Verify the platform binary was installed (optional deps can be silently skipped)
           if ! node -e "require.resolve('@limlabs/rex-linux-x64/package.json')" 2>/dev/null; then
             echo "Platform package missing after install, installing explicitly..."
-            npm install @limlabs/rex-linux-x64
+            npm install @limlabs/rex-linux-x64@"$VERSION"
           fi
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
 
       - name: rex build
-        run: npx rex build
+        run: ./node_modules/.bin/rex build
         working-directory: fixtures/${{ matrix.fixture }}
 
       - name: rex start (verify HTTP 200)
         run: |
-          npx rex start --port 3000 &
+          ./node_modules/.bin/rex start --port 3000 &
           REX_PID=$!
 
           # Wait for server to be ready


### PR DESCRIPTION
## Summary
- Remove `package-lock.json` before `npm install` in smoke tests — the lockfile contains `file:../../packages/rex` references from local dev that prevent npm from resolving the published version from the registry
- Replace `npx rex` with `./node_modules/.bin/rex` — npx can silently download a fresh copy to a temp dir if local bin linking breaks, causing `require.resolve` for the platform package to fail
- Pin the explicit fallback platform install to the exact version under test

## Context
Every smoke test in the 0.16.0 release failed with:
```
The platform-specific package @limlabs/rex-linux-x64 is not installed.
```
despite the package being successfully installed moments earlier. The stale lockfile was causing npm to resolve `@limlabs/rex` from the local `file:` path instead of the registry, breaking optional dependency resolution.

## Test plan
- [ ] Merge and verify smoke tests pass on next release-please run
- [ ] Can also test by manually triggering the smoke-test workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix smoke test CI by removing stale lockfile and using local `rex` binary
> - Removes `package-lock.json` before the install step so npm resolves packages from the correct registry.
> - Pins `@limlabs/rex-linux-x64` to the version from `INPUT_VERSION`, passed via an explicit `env` block in the install step.
> - Replaces `npx rex` with `./node_modules/.bin/rex` in the build and start steps to avoid npx resolution issues.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fa3fe7a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->