### PR TITLE
fix(dev): trigger hot reload for imported files outside pages/app

### DIFF
--- a/crates/rex_dev/src/rebuild.rs
+++ b/crates/rex_dev/src/rebuild.rs
@@ -23,7 +23,8 @@ pub async fn handle_file_event(
         FileEventKind::PageModified
         | FileEventKind::CssModified
         | FileEventKind::MiddlewareModified
-        | FileEventKind::McpModified => {
+        | FileEventKind::McpModified
+        | FileEventKind::SourceModified => {
             let t0 = Instant::now();
 
             // Rescan, rebuild, reload isolates, update hot state

--- a/crates/rex_dev/src/watcher.rs
+++ b/crates/rex_dev/src/watcher.rs
@@ -13,6 +13,8 @@ pub enum FileEventKind {
     CssModified,
     MiddlewareModified,
     McpModified,
+    /// A source file outside pages/app dirs was modified (e.g. components/, lib/)
+    SourceModified,
 }
 
 #[derive(Debug, Clone)]
@@ -25,6 +27,7 @@ pub struct FileEvent {
 ///
 /// Watches recursively but skips `node_modules/`, `.rex/`, `.git/`, and `target/`.
 /// - `.tsx/.ts/.jsx/.js/.mdx` files under `pages_dir` or `app_dir` → PageModified / PageRemoved
+/// - `.tsx/.ts/.jsx/.js/.mdx` files elsewhere in project → SourceModified
 /// - `.css` files anywhere → CssModified
 pub fn start_watcher(
     project_root: &Path,
@@ -79,6 +82,9 @@ pub fn start_watcher(
                                     } else {
                                         FileEventKind::PageRemoved
                                     }
+                                } else if is_page_file(&path) && path.exists() {
+                                    // Source file outside pages/app (e.g. components/, lib/)
+                                    FileEventKind::SourceModified
                                 } else {
                                     continue;
                                 }

--- a/crates/rex_dev/tests/watcher.rs
+++ b/crates/rex_dev/tests/watcher.rs
@@ -147,6 +147,44 @@ fn node_modules_changes_are_ignored() {
 }
 
 #[test]
+fn source_file_outside_pages_triggers_source_modified() {
+    let (_tmp, root, rx) = setup_watcher();
+    let components_dir = root.join("components");
+    fs::create_dir_all(&components_dir).unwrap();
+    std::thread::sleep(Duration::from_millis(200));
+
+    let component = components_dir.join("Button.tsx");
+    fs::write(&component, "export function Button() { return <button/>; }").unwrap();
+
+    let events = collect_events(&rx, Duration::from_secs(3));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e.kind, FileEventKind::SourceModified)),
+        "Expected SourceModified for components/Button.tsx, got: {events:?}"
+    );
+}
+
+#[test]
+fn lib_file_outside_pages_triggers_source_modified() {
+    let (_tmp, root, rx) = setup_watcher();
+    let lib_dir = root.join("lib");
+    fs::create_dir_all(&lib_dir).unwrap();
+    std::thread::sleep(Duration::from_millis(200));
+
+    let util = lib_dir.join("utils.ts");
+    fs::write(&util, "export const add = (a: number, b: number) => a + b;").unwrap();
+
+    let events = collect_events(&rx, Duration::from_secs(3));
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e.kind, FileEventKind::SourceModified)),
+        "Expected SourceModified for lib/utils.ts, got: {events:?}"
+    );
+}
+
+#[test]
 fn app_dir_page_removal_triggers_page_removed() {
     let (_tmp, root, rx) = setup_watcher();
     let page = root.join("app/page.tsx");


### PR DESCRIPTION
## Summary

- The file watcher only emitted events for source files inside `pages/` or `app/` directories. Imported files like `components/Button.tsx` or `lib/utils.ts` were silently ignored, requiring a manual restart to see changes.
- Adds a `SourceModified` event kind for `.tsx/.ts/.jsx/.js/.mdx` files anywhere in the project (excluding `node_modules`, `.rex`, `.git`, `target`) and handles it the same as `PageModified` — full rescan, rebuild, V8 reload, and HMR update.
- Adds two integration tests verifying `components/` and `lib/` file changes emit `SourceModified`.

## Test plan

- [x] New integration tests: `source_file_outside_pages_triggers_source_modified`, `lib_file_outside_pages_triggers_source_modified`
- [x] All 9 watcher tests pass
- [x] All 29 E2E tests pass (pre-push hook)
- [ ] Manual: run `rex dev` on a project, edit an imported component file, verify browser reloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger hot reload for source files outside pages/app directories
> - Adds a `SourceModified` variant to the `FileEventKind` enum in [watcher.rs](https://github.com/limlabs/rex/pull/180/files#diff-b6b25e6b295970b1811f97c247d9beba67a7eea81c8d67bd3b7f087780b7ddf7) to classify `.tsx/.ts/.jsx/.js/.mdx` files outside `pages_dir` and `app_dir` (e.g., `components/`, `lib/`).
> - Updates [rebuild.rs](https://github.com/limlabs/rex/pull/180/files#diff-61fe8d665bf50c2cacd5bb9ebcc07d999ae856adaa57578e23cbd2c8343a436c) to handle `SourceModified` with the same full rebuild and HMR reload sequence used for `PageModified` and other event kinds.
> - Adds two integration tests covering `components/Button.tsx` and `lib/utils.ts` to verify `SourceModified` is emitted correctly.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 92edbbe.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->