### PR TITLE
fix(v8): remove crates.io version req for unpublishable rex_build dev-dep

### DIFF
--- a/crates/rex_v8/Cargo.toml
+++ b/crates/rex_v8/Cargo.toml
@@ -26,7 +26,7 @@ webpki-roots = "0.26"
 rustls-pki-types = "1"
 
 [dev-dependencies]
-rex_build = { path = "../rex_build", version = "0.17.1" } # x-release-please-version
+rex_build = { path = "../rex_build" }
 tempfile = "3"
 tokio = { workspace = true, features = ["macros", "rt"] }
 tracing-subscriber = { workspace = true }


### PR DESCRIPTION
## Summary
- `rex_build` has `publish = false` (git-only rolldown deps prevent crates.io publishing)
- `rex_v8` listed it as a dev-dependency with `version = "0.17.1"`, causing `cargo publish` to look it up on the crates.io registry
- Removed the `version` field and `x-release-please-version` comment — cargo strips path-only dev-deps from published packages, so no registry lookup occurs

Fixes the release-please error:
```
no matching package named `rex_build` found
location searched: crates.io index
required by package `rex_v8 v0.17.1`
```

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy` passes
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove version constraint from `rex_build` dev-dependency in `rex_v8`
> Removes the explicit `version` field from the `rex_build` dev-dependency in [Cargo.toml](https://github.com/limlabs/rex/pull/186/files#diff-84fbf699d6d6c1defec443879daef362ade1f976c82b7586a4956d238f36328a), leaving only the `path` reference. Since `rex_build` is not published to crates.io, specifying a version requirement is unnecessary and can cause issues.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c77adf8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->