### PR TITLE
fix(init): use react-jsx transform so React import is not required

### DIFF
--- a/crates/rex_e2e/tests/init_e2e.rs
+++ b/crates/rex_e2e/tests/init_e2e.rs
@@ -72,10 +72,7 @@ mod init {
             .status()
             .unwrap();
 
-        assert!(
-            init_status.success(),
-            "rex init should exit successfully"
-        );
+        assert!(init_status.success(), "rex init should exit successfully");
         assert!(
             project_dir.join("pages/index.tsx").exists(),
             "rex init should create pages/index.tsx"


### PR DESCRIPTION
## Summary
- `rex init` generated tsconfig with `"jsx": "react"` (classic transform), which compiles JSX to `React.createElement(...)` — but the template `pages/index.tsx` has no `import React`, causing "React is not defined" at runtime
- Changed to `"jsx": "react-jsx"` (automatic transform) which auto-imports from `react/jsx-runtime` and doesn't require React in scope
- Added E2E test (`init_e2e.rs`) that runs `rex init` → `rex dev` → verifies the page renders with SSR content

## Test plan
- [x] E2E test `e2e_init_project_starts_without_error` passes (runs `rex init`, starts dev server, fetches index page)
- [x] All 29 existing E2E tests pass (pre-push hook)
- [x] `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `rex init` template to use react-jsx transform, removing the need to import React
> - Updates the project template generated by `rex init` to use the automatic JSX transform (`react-jsx`), so generated components no longer need an explicit `import React` statement.
> - Adds an end-to-end test in [init_e2e.rs](https://github.com/limlabs/rex/pull/188/files#diff-3ee3ce9afadfabe8e2a520ee18cef7e69477dcffc22ee79bdfe3e808730f8e3f) that runs `rex init`, starts `rex dev`, polls the server for up to 60s, and asserts the index route returns HTTP 200 with expected SSR content markers.
> - The E2E test is marked `#[ignore]` and resolves the `rex` binary via `REX_BIN` env var or falls back to `target/debug/rex` / `target/release/rex`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 66e0ebc.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->