### PR TITLE
fix(docs): dismiss mobile menu on nav and highlight active link

### DIFF
--- a/docs/components/Sidebar.tsx
+++ b/docs/components/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import Link from "rex/link";
 
 interface NavItem {
@@ -55,6 +55,25 @@ const navigation: NavSection[] = [
 
 export default function Sidebar() {
   const [open, setOpen] = useState(false);
+  const [pathname, setPathname] = useState("");
+
+  useEffect(() => {
+    setPathname(window.location.pathname);
+
+    function onPopState() {
+      setPathname(window.location.pathname);
+    }
+    window.addEventListener("popstate", onPopState);
+    return () => window.removeEventListener("popstate", onPopState);
+  }, []);
+
+  const handleNavClick = useCallback(() => {
+    setOpen(false);
+    // Defer pathname update to after navigateTo pushes the new URL
+    requestAnimationFrame(() => {
+      setPathname(window.location.pathname);
+    });
+  }, []);
 
   return (
     <>
@@ -98,16 +117,23 @@ export default function Sidebar() {
                 {section.title}
               </h3>
               <ul className="space-y-0.5">
-                {section.items.map((item) => (
-                  <li key={item.href}>
-                    <Link
-                      href={item.href}
-                      className="block px-2 py-1.5 rounded text-sm text-slate-400 hover:text-white hover:bg-slate-800 transition-colors no-underline"
-                    >
-                      {item.title}
-                    </Link>
-                  </li>
-                ))}
+                {section.items.map((item) => {
+                  const active = pathname === item.href;
+                  return (
+                    <li key={item.href} onClick={handleNavClick}>
+                      <Link
+                        href={item.href}
+                        className={`block px-2 py-1.5 rounded text-sm transition-colors no-underline ${
+                          active
+                            ? "text-white bg-slate-800"
+                            : "text-slate-400 hover:text-white hover:bg-slate-800"
+                        }`}
+                      >
+                        {item.title}
+                      </Link>
+                    </li>
+                  );
+                })}
               </ul>
             </div>
           ))}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,24 +2,30 @@ pre-commit:
   parallel: false
   commands:
     fmt:
+      glob: "**/*.rs"
       run: cargo fmt --check
       fail_text: "Run `cargo fmt` to fix formatting"
     check:
+      glob: "**/*.rs"
       run: RUSTFLAGS="-D warnings" cargo check --all-targets
       fail_text: "Fix build warnings before committing"
     clippy:
+      glob: "**/*.rs"
       run: cargo clippy --all-targets -- -D warnings
       fail_text: "Fix clippy warnings before committing"
     no-js:
       run: "! git diff --cached --name-only --diff-filter=ACR | grep '\\.js$' | grep -v '^packages/rex/bin/' | grep -q ."
       fail_text: "Do not commit .js files — use TypeScript (.ts/.tsx) instead"
     oxlint:
-      run: npx oxlint --deny-warnings runtime/ packages/rex/src/ benchmarks/
+      glob: "**/*.{ts,tsx,js,jsx}"
+      run: oxlint --deny-warnings runtime/ packages/rex/src/ benchmarks/
       fail_text: "Fix oxlint warnings before committing"
     typecheck:
+      glob: "runtime/**/*.{ts,tsx}"
       run: cd runtime && { [ -d node_modules ] || npm install --no-package-lock --ignore-scripts --no-audit --no-fund; } && npm run typecheck
       fail_text: "Fix TypeScript errors in runtime/"
     typecheck-fixtures:
+      glob: "**/*.{ts,tsx}"
       run: scripts/typecheck-fixtures.sh
       fail_text: "Fix TypeScript errors in fixtures/benchmarks before committing"
     file-length:


### PR DESCRIPTION
## Summary
- **Mobile menu dismiss**: clicking a nav link now closes the sidebar on mobile
- **Active link state**: tracks pathname and highlights the current page's nav link
- **lefthook: replace `npx oxlint` with `oxlint`**: `npx`/`npm exec` was hanging indefinitely on package resolution, causing commits to stall. Direct binary call completes in 42ms.
- **lefthook: add glob filters**: scope cargo hooks to `**/*.rs` so they're skipped for non-Rust commits

## Test plan
- [ ] Open docs on mobile, tap a nav link → menu should dismiss
- [ ] Navigate between pages → active link should be highlighted
- [ ] Commit a non-Rust change → cargo hooks should be skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Highlight active nav link and dismiss mobile menu on click in docs Sidebar
> - The [Sidebar](https://github.com/limlabs/rex/pull/191/files#diff-3f429715a03d965d56a5c602fc5e6967d2c81525df8be817037b17c8baf7d6f2) now tracks `window.location.pathname` to highlight the active nav item, updating on both direct navigation and browser back/forward via `popstate`.
> - Clicking a nav item closes the mobile menu and defers a pathname sync using `requestAnimationFrame` to capture the updated URL after navigation.
> - Pre-commit hook globs in [lefthook.yml](https://github.com/limlabs/rex/pull/191/files#diff-ad6a01e589b8b1b214ca310dbb8d2e4314f6c612b921050c73c97455de43884d) are tightened so Rust, TypeScript, and JavaScript commands only run on matching files; `oxlint` now runs directly instead of via `npx`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1f98c46.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->