### PR TITLE
ci: remove Docker build caching from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,16 +98,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build rex images (app-build + runtime in parallel)
-        uses: docker/bake-action@v6
-        with:
-          load: true
-          set: |
-            *.cache-from=type=gha,scope=docker
-            *.cache-to=type=gha,scope=docker,mode=max
+      - name: Build rex images
+        run: docker buildx bake --load
 
       - name: Build railway fixture
         run: docker build --build-arg REX_VERSION=ci -t rex-railway-fixture fixtures/railway


### PR DESCRIPTION
## Summary
- Removed GHA cache configuration (`cache-from`/`cache-to`) from the Docker CI job
- Replaced `docker/bake-action` with a plain `docker buildx bake --load` command
- The buildx cache layer was adding overhead without meaningful speedup

## Test plan
- [ ] Verify the `docker` CI job passes without cache config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove Docker build caching from CI
> Replaces the `docker/setup-buildx-action` and `docker/bake-action` steps in [ci.yml](.github/workflows/ci.yml) with a single `docker buildx bake --load` run step, removing all GHA `cache-from`/`cache-to` configuration.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 477293b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->