### PR TITLE
fix(rsc): ensure complete flight data for async server components

### DIFF
--- a/crates/rex_v8/src/fetch.rs
+++ b/crates/rex_v8/src/fetch.rs
@@ -469,7 +469,7 @@ const FETCH_LOOP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(3
 
 /// Call `globalThis.__rex_drain_timers()` — fires expired setTimeout callbacks.
 /// Returns true if any timer was fired.
-fn drain_js_timers(isolate: &mut v8::OwnedIsolate, context: &v8::Global<v8::Context>) -> bool {
+pub fn drain_js_timers(isolate: &mut v8::OwnedIsolate, context: &v8::Global<v8::Context>) -> bool {
     v8::scope_with_context!(scope, isolate, context);
     let global = context.open(scope).global(scope);
 

--- a/crates/rex_v8/src/ssr_isolate_rsc.rs
+++ b/crates/rex_v8/src/ssr_isolate_rsc.rs
@@ -184,7 +184,16 @@ impl SsrIsolate {
                 return Err(anyhow::anyhow!("RSC async resolution timed out after 10s"));
             }
 
+            // Process any pending I/O (fetch, TCP sockets)
             crate::fetch::run_fetch_loop(&mut self.isolate, &self.context);
+
+            // Pump microtasks and timers to full convergence.
+            // run_fetch_loop exits when there is no I/O work, but React's
+            // internal rendering may still need microtask rounds (promise
+            // chains, ReadableStream chunk delivery, setTimeout(0) scheduling)
+            // to fully resolve async server components and close the flight
+            // data stream.
+            self.drain_microtasks_and_timers();
 
             let status = {
                 v8::scope_with_context!(scope, &mut self.isolate, &self.context);
@@ -203,7 +212,7 @@ impl SsrIsolate {
                 }
                 "pending" => {
                     // Yield briefly to avoid CPU-spinning when async slots are
-                    // waiting on microtasks but no fetch requests are queued.
+                    // waiting on external I/O (fetch, timers with real delays).
                     std::thread::sleep(std::time::Duration::from_millis(1));
                     continue;
                 }
@@ -213,6 +222,40 @@ impl SsrIsolate {
             }
         }
         Ok(())
+    }
+
+    /// Pump V8 microtasks and JS timers until no more progress is made.
+    ///
+    /// This ensures React's internal rendering state (ReadableStream chunk
+    /// delivery, promise chains from async server components, SSR pass
+    /// promises) fully converges after I/O operations complete. Without
+    /// this, the flight data stream may not have closed yet when we check
+    /// `__rex_resolve_rsc_pending()`, leading to incomplete flight data
+    /// being embedded in the HTML response.
+    fn drain_microtasks_and_timers(&mut self) {
+        // Cap iterations to prevent infinite loops from buggy JS timer chains.
+        for _ in 0..1000 {
+            self.isolate.perform_microtask_checkpoint();
+
+            let timer_fired = crate::fetch::drain_js_timers(&mut self.isolate, &self.context);
+            if timer_fired {
+                // Timer callbacks may have queued microtasks — drain them,
+                // then check for more expired timers.
+                self.isolate.perform_microtask_checkpoint();
+                continue;
+            }
+
+            // If microtask processing produced new fetch requests, stop
+            // here — the caller's next run_fetch_loop iteration will
+            // handle them.
+            let has_new_fetch = crate::fetch::FETCH_QUEUE.with(|q| !q.borrow().is_empty());
+            if has_new_fetch {
+                break;
+            }
+
+            // No timers fired and no new fetch requests — converged.
+            break;
+        }
     }
 
     /// List registered MCP tools. Returns JSON array of {name, description, parameters}.

--- a/runtime/rsc/flight.ts
+++ b/runtime/rsc/flight.ts
@@ -159,8 +159,10 @@ function _assembleChunks(): string {
     const parts: string[] = [];
     for (let i = 0; i < _chunks.length; i++) {
         const c = _chunks[i];
-        parts.push(typeof c === 'string' ? c : decoder.decode(c));
+        // stream: true so multi-byte chars spanning chunk boundaries decode correctly
+        parts.push(typeof c === 'string' ? c : decoder.decode(c, { stream: true }));
     }
+    parts.push(decoder.decode()); // flush remaining bytes
     _chunks = [];
     return parts.join('');
 }


### PR DESCRIPTION
## Summary

Fixes incomplete RSC flight data that caused client-side `Connection closed` errors during hydration when pages use async server components (e.g., Payload CMS data fetching).

- **Fix `_assembleChunks()` TextDecoder** — use `{ stream: true }` so multi-byte characters spanning chunk boundaries are decoded correctly instead of being replaced with U+FFFD. The SSR pass uses raw binary chunks (correct) but the client receives the text version via `_flightString`, so encoding corruption there causes the flight parser to fail.

- **Add `drain_microtasks_and_timers()` convergence loop** — after `run_fetch_loop` exits (no I/O work remaining), pump V8 microtasks and JS timers to full convergence before checking `__rex_resolve_rsc_pending()`. This ensures React's internal rendering state (ReadableStream chunk delivery, promise chains, setTimeout(0) scheduling) fully settles before the flight data completeness check.

## Test plan

- [x] All unit/integration tests pass (`cargo test`)
- [x] All E2E tests pass (`cargo test -p rex_e2e -- --ignored`)
- [x] Coverage meets threshold (66%)
- [x] Clippy, fmt, oxlint, typecheck all clean
- [x] Tested against `liminal-sh` (Payload CMS) — flight data complete with 1224 chunks, 121 IDs, 7 lazy refs, 0 dangling

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix incomplete flight data for async RSC by draining microtasks and timers before resolution
> - Adds a `drain_microtasks_and_timers` helper in [`ssr_isolate_rsc.rs`](https://github.com/limlabs/rex/pull/207/files#diff-98099631e5ff8e012198541a7aefe138daf919c3136234e8b4ad8dd24a82949b) that runs up to 1000 iterations of V8 microtask checkpoints and expired JS timer callbacks before calling `__rex_resolve_rsc_pending()`, ensuring pending async work completes within the same iteration.
> - Fixes streaming UTF-8 decoding in [`_assembleChunks`](https://github.com/limlabs/rex/pull/207/files#diff-acd97b84cb524ba22a84999c2bf45b6e6c467a1fe7dae7ddf758283d6b1b9258) by passing `{ stream: true }` to `TextDecoder.decode` and flushing trailing bytes, correcting multi-byte character handling at chunk boundaries.
> - Makes `drain_js_timers` public in [`fetch.rs`](https://github.com/limlabs/rex/pull/207/files#diff-2bb12949db65f5adf87c1df64951fd78bb128837f740e9b5ba86a67afdc87c8f) to support the new helper.
> - Behavioral Change: RSC resolution now pumps microtasks and timers after each fetch-loop iteration, which may change timing of async callback execution during SSR.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c09d76b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->