### PR TITLE
fix(rsc): filter empty chunk URLs from client module map

### DIFF
--- a/crates/rex_core/src/client_manifest.rs
+++ b/crates/rex_core/src/client_manifest.rs
@@ -64,6 +64,28 @@ impl ClientReferenceManifest {
         serde_json::Value::Object(config)
     }
 
+    /// Serialize the client-facing module map as JSON.
+    ///
+    /// This is embedded in the HTML as `window.__REX_RSC_MODULE_MAP__` and used
+    /// by the hydration runtime to preload client component chunks. Entries with
+    /// empty `chunk_url` (placeholders from the server build phase that were never
+    /// resolved to a real chunk) are excluded — importing an empty specifier
+    /// crashes the browser with `TypeError: Failed to resolve module specifier ''`.
+    pub fn to_client_module_map_json(&self) -> String {
+        let filtered: HashMap<&String, &ClientRefEntry> = self
+            .entries
+            .iter()
+            .filter(|(_, entry)| !entry.chunk_url.is_empty())
+            .collect();
+
+        #[derive(Serialize)]
+        struct Wrapper<'a> {
+            entries: HashMap<&'a String, &'a ClientRefEntry>,
+        }
+
+        serde_json::to_string(&Wrapper { entries: filtered }).unwrap_or_else(|_| "{}".to_string())
+    }
+
     /// Produce the SSR-side webpack module map for `createFromReadableStream`.
     ///
     /// React's client looks up `config[moduleId][exportName]` → `{ id, name, chunks }`.
@@ -155,5 +177,25 @@ mod tests {
         let wildcard = ref1.get("*").unwrap();
         assert_eq!(wildcard["id"], "ref1");
         assert_eq!(wildcard["name"], "");
+    }
+
+    #[test]
+    fn client_module_map_excludes_empty_chunk_urls() {
+        let mut manifest = ClientReferenceManifest::new();
+        // Real entry with a chunk URL
+        manifest.add("ref1", "/Counter.js".to_string(), "default".to_string());
+        // Placeholder entry with empty chunk URL (from server build phase)
+        manifest.add("ref2", String::new(), "Widget".to_string());
+
+        let json = manifest.to_client_module_map_json();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let entries = parsed["entries"].as_object().unwrap();
+
+        // ref1 should be present (has chunk URL)
+        assert!(entries.contains_key("ref1"), "ref1 should be included");
+        assert_eq!(entries["ref1"]["chunk_url"], "/Counter.js");
+
+        // ref2 should be excluded (empty chunk URL)
+        assert!(!entries.contains_key("ref2"), "ref2 should be excluded");
     }
 }

--- a/crates/rex_server/src/handlers/rsc.rs
+++ b/crates/rex_server/src/handlers/rsc.rs
@@ -136,12 +136,12 @@ pub(super) async fn render_app_route(
         .map(|a| a.client_chunks.clone())
         .unwrap_or_default();
 
-    // Serialize client reference manifest
+    // Serialize client reference manifest (excludes placeholder entries with empty chunk_url)
     let client_manifest_json = hot
         .manifest
         .client_reference_manifest
         .as_ref()
-        .and_then(|m| serde_json::to_string(m).ok())
+        .map(|m| m.to_client_module_map_json())
         .unwrap_or_else(|| "{}".to_string());
 
     let is_dev = state.is_dev;

--- a/crates/rex_server/src/prerender.rs
+++ b/crates/rex_server/src/prerender.rs
@@ -150,10 +150,11 @@ pub async fn prerender_static_app_routes(
     let static_app_routes = collect_static_app_routes(manifest);
 
     // Client manifest JSON needed for RSC document assembly
+    // Uses to_client_module_map_json() to exclude placeholder entries with empty chunk_url
     let client_manifest_json = manifest
         .client_reference_manifest
         .as_ref()
-        .and_then(|m| serde_json::to_string(m).ok())
+        .map(|m| m.to_client_module_map_json())
         .unwrap_or_else(|| "{}".to_string());
 
     for (pattern, assets) in &static_app_routes {

--- a/runtime/client/rsc-hydrate.ts
+++ b/runtime/client/rsc-hydrate.ts
@@ -98,6 +98,7 @@ function preloadClientModules(): Promise<void | unknown[]> {
   for (const refId in entries) {
     if (!Object.prototype.hasOwnProperty.call(entries, refId)) continue;
     const entry = entries[refId];
+    if (!entry || !entry.chunk_url) continue;
     // Use an IIFE to capture refId in closure
     (function(id: string, url: string) {
       promises.push(


### PR DESCRIPTION
## Summary
- During RSC builds, placeholder manifest entries are created with empty `chunk_url` for the server webpack config. If the client bundle build doesn't overwrite all placeholders (e.g., chunk name mismatch between rolldown output and boundary lookup), these empty URLs reach the browser and crash with `TypeError: Failed to resolve module specifier ''`
- Added `ClientReferenceManifest::to_client_module_map_json()` that filters out entries with empty `chunk_url`, and switched both the RSC handler and prerender paths to use it
- Added a defensive skip in the client hydration runtime (`rsc-hydrate.ts`) for entries with falsy `chunk_url`

Fixes: `__rsc_hydrate-*.js [Rex RSC] Module preload failed: TypeError: Failed to resolve module specifier ''`

## Test plan
- [x] New unit test `client_module_map_excludes_empty_chunk_urls` verifies filtering
- [x] `cargo clippy -p rex_core -p rex_server -- -D warnings` passes
- [x] Full E2E test suite passes (29/29)
- [x] Coverage gate passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Filter empty chunk URLs from the RSC client module map
> Manifest entries with an empty `chunk_url` were being serialized into `__REX_RSC_MODULE_MAP__` and later causing dynamic imports with empty specifiers during hydration.
>
> - Adds `ClientReferenceManifest::to_client_module_map_json` in [client_manifest.rs](https://github.com/limlabs/rex/pull/209/files#diff-fd7719ef640b6a28e3a820e925a732c9d194efe0382fe26d434ee6d9bd223370) which serializes only entries with a non-empty `chunk_url` under a top-level `entries` key.
> - Updates [rsc.rs](https://github.com/limlabs/rex/pull/209/files#diff-b5f58fc35507436e17cc36e65abeb60acc796951854baa817a644b23e8edad36) and [prerender.rs](https://github.com/limlabs/rex/pull/209/files#diff-d5d89b0a9fc14e14ea0e2a5beb0577eb6f63f3e5b7ab39f56b0777bc33f5f294) to use the new method instead of `serde_json::to_string`.
> - Adds a guard in `preloadClientModules` in [rsc-hydrate.ts](https://github.com/limlabs/rex/pull/209/files#diff-0152d2711e561aac897cf41ac3c339ec55a3500b5c0ad038b0652c4bfca1ff08) to skip falsy entries or entries without a valid `chunk_url` before attempting dynamic import.
> - Behavioral Change: the embedded module map JSON now uses a new `{ entries: { ... } }` shape instead of a flat object.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8739aef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->