### PR TITLE
fix(benchmarks): upgrade undici to resolve Dependabot alerts

### DIFF
--- a/benchmarks/tanstack-basic/package-lock.json
+++ b/benchmarks/tanstack-basic/package-lock.json
@@ -2861,9 +2861,9 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.22.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
-      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "version": "7.24.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.3.tgz",
+      "integrity": "sha512-eJdUmK/Wrx2d+mnWWmwwLRyA7OQCkLap60sk3dOK4ViZR7DKwwptwuIvFBg2HaiP9ESaEdhtpSymQPvytpmkCA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"


### PR DESCRIPTION
## Summary
- Upgrades transitive `undici` dependency in `benchmarks/tanstack-basic` from vulnerable version to 7.24.3
- Resolves all 5 open Dependabot security alerts (3 high, 2 medium severity)

## Alerts resolved
- #7 HTTP Request/Response Smuggling (medium)
- #8 Malicious WebSocket 64-bit length overflow (high)
- #9 Unbounded Memory Consumption in DeduplicationHandler (medium)
- #10 CRLF Injection via `upgrade` option (medium)
- #11 Unbounded Memory Consumption in WebSocket permessage-deflate (high)
- #12 Unhandled Exception in WebSocket Client (high)

## Test plan
- [x] `npm audit` shows 0 vulnerabilities
- [x] Pre-push hooks pass (coverage + E2E tests: 29/29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Upgrade `undici` in benchmarks to resolve Dependabot alerts
> Updates the `undici` dependency in [package-lock.json](https://github.com/limlabs/rex/pull/217/files#diff-b991f7d0c5c598bc30bb4145bf3ac59f2e7036291fc2507a986a7d514789eeff) to address security vulnerabilities flagged by Dependabot.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 570e28f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->