### PR TITLE
feat(docs): add version to sidebar, publish docs on release

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -25,17 +25,43 @@ jobs:
       beta_tag: ${{ steps.version.outputs.beta_tag }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Extract version from manifest
+      - name: Compute next version from conventional commits
         id: version
         run: |
-          VERSION=$(jq -r '."."' .release-please-manifest.json)
-          BETA_VERSION="${VERSION}-beta.${{ github.run_number }}"
+          CURRENT=$(jq -r '."."' .release-please-manifest.json)
+          LAST_TAG="v${CURRENT}"
+
+          # Determine bump type by scanning commits since last release
+          BUMP="patch"
+          if git rev-parse "$LAST_TAG" >/dev/null 2>&1; then
+            COMMITS=$(git log "${LAST_TAG}..HEAD" --pretty=format:"%s")
+            BODIES=$(git log "${LAST_TAG}..HEAD" --pretty=format:"%b")
+            # Breaking changes -> minor (bump-minor-pre-major while <1.0)
+            if echo "$COMMITS" | grep -qE '^[a-z]+(\(.*\))?!:' || echo "$BODIES" | grep -qE '^BREAKING CHANGE:'; then
+              BUMP="minor"
+            # Features -> minor
+            elif echo "$COMMITS" | grep -qE '^feat(\(.*\))?:'; then
+              BUMP="minor"
+            fi
+          fi
+
+          # Apply bump
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT"
+          case "$BUMP" in
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+          NEXT_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+          BETA_VERSION="${NEXT_VERSION}-beta.${{ github.run_number }}"
           BETA_TAG="v${BETA_VERSION}"
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "version=$NEXT_VERSION" >> "$GITHUB_OUTPUT"
           echo "beta_version=$BETA_VERSION" >> "$GITHUB_OUTPUT"
           echo "beta_tag=$BETA_TAG" >> "$GITHUB_OUTPUT"
-          echo "::notice::Beta version: $BETA_VERSION (tag: $BETA_TAG)"
+          echo "::notice::Current: $CURRENT, bump: $BUMP, next: $NEXT_VERSION, beta: $BETA_VERSION"
 
   build-linux:
     name: Build Linux (x86_64)

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -1,0 +1,69 @@
+name: Deploy Docs
+
+on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Version string to display in the docs sidebar"
+        required: true
+        type: string
+      docker-tag:
+        description: "GHCR image tag to use for rex export (e.g. latest-build, beta-build)"
+        required: false
+        type: string
+        default: "latest-build"
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".node-version"
+          cache: "npm"
+          cache-dependency-path: docs/package-lock.json
+
+      - name: Install dependencies
+        run: npm install
+        working-directory: docs
+
+      - name: Inject version
+        run: echo 'export const VERSION = "${{ inputs.version }}";' > docs/lib/version.ts
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Export docs site
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/work" \
+            -w /work/docs \
+            ghcr.io/limlabs/rex:${{ inputs.docker-tag }} \
+            rex export --force --base-path /rex
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/.rex/export
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,54 +13,19 @@ permissions:
   id-token: write
   packages: read
 
-concurrency:
-  group: pages
-  cancel-in-progress: false
-
 jobs:
-  build:
+  version:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.v.outputs.version }}
     steps:
       - uses: actions/checkout@v4
+      - name: Read version from manifest
+        id: v
+        run: echo "version=$(jq -r '."."' .release-please-manifest.json)" >> "$GITHUB_OUTPUT"
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version-file: ".node-version"
-          cache: "npm"
-          cache-dependency-path: docs/package-lock.json
-
-      - name: Install dependencies
-        run: npm install
-        working-directory: docs
-
-      - name: Log in to GHCR
-        uses: docker/login-action@v3
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Export docs site
-        run: |
-          docker run --rm \
-            -v "${{ github.workspace }}:/work" \
-            -w /work/docs \
-            ghcr.io/limlabs/rex:latest-build \
-            rex export --force --base-path /rex
-
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: docs/.rex/export
-
-  deploy:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+  deploy-docs:
+    needs: version
+    uses: ./.github/workflows/deploy-docs.yml
+    with:
+      version: ${{ needs.version.outputs.version }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,6 +13,8 @@ permissions:
   contents: write
   pull-requests: write
   packages: write
+  pages: write
+  id-token: write
 
 env:
   CARGO_TERM_COLOR: always
@@ -23,6 +25,7 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
+      version: ${{ steps.version.outputs.version }}
       pr_branch: ${{ steps.release.outputs.pr && fromJSON(steps.release.outputs.pr).headBranchName || '' }}
     steps:
       - uses: googleapis/release-please-action@v4
@@ -31,6 +34,13 @@ jobs:
           token: ${{ secrets.RELEASE_PAT }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+
+      - name: Extract version from tag
+        id: version
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
+        run: echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+        env:
+          TAG: ${{ steps.release.outputs.tag_name }}
 
   update-lockfiles:
     name: Update lockfiles on release PR
@@ -494,3 +504,12 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+
+  deploy-docs:
+    name: Deploy Docs
+    needs: [release-please, docker, npm-publish, smoke-test, cargo-publish, deploy-railway, smoke-test-railway]
+    if: ${{ needs.release-please.outputs.releases_created == 'true' }}
+    uses: ./.github/workflows/deploy-docs.yml
+    with:
+      version: ${{ needs.release-please.outputs.version }}
+      docker-tag: latest-build

--- a/docs/components/Sidebar.tsx
+++ b/docs/components/Sidebar.tsx
@@ -1,7 +1,8 @@
-"use client";
+'use client';
 
-import React, { useState, useEffect, useCallback } from "react";
-import Link from "rex/link";
+import React, { useState, useEffect, useCallback } from 'react';
+import Link from 'rex/link';
+import { VERSION } from '../lib/version';
 
 interface NavItem {
   title: string;
@@ -15,48 +16,48 @@ interface NavSection {
 
 const navigation: NavSection[] = [
   {
-    title: "Getting Started",
+    title: 'Getting Started',
     items: [
-      { title: "Quickstart", href: "/getting-started" },
-      { title: "Installation", href: "/getting-started/installation" },
+      { title: 'Quickstart', href: '/getting-started' },
+      { title: 'Installation', href: '/getting-started/installation' },
     ],
   },
   {
-    title: "How Rex Works",
+    title: 'How Rex Works',
     items: [
-      { title: "Motivations", href: "/architecture/motivations" },
-      { title: "Architecture", href: "/architecture" },
-      { title: "Differences from Next.js", href: "/architecture/differences" },
+      { title: 'Motivations', href: '/architecture/motivations' },
+      { title: 'Architecture', href: '/architecture' },
+      { title: 'Differences from Next.js', href: '/architecture/differences' },
     ],
   },
   {
-    title: "Features",
+    title: 'Features',
     items: [
-      { title: "Routing", href: "/features/routing" },
-      { title: "Data Fetching", href: "/features/data-fetching" },
-      { title: "Styling", href: "/features/styling" },
-      { title: "Middleware", href: "/features/middleware" },
-      { title: "Custom Server", href: "/features/custom-server" },
-      { title: "MDX", href: "/features/mdx" },
-      { title: "Live Mode", href: "/features/live-mode" },
+      { title: 'Routing', href: '/features/routing' },
+      { title: 'Data Fetching', href: '/features/data-fetching' },
+      { title: 'Styling', href: '/features/styling' },
+      { title: 'Middleware', href: '/features/middleware' },
+      { title: 'Custom Server', href: '/features/custom-server' },
+      { title: 'MDX', href: '/features/mdx' },
+      { title: 'Live Mode', href: '/features/live-mode' },
     ],
   },
   {
-    title: "Reference",
+    title: 'Reference',
     items: [
-      { title: "CLI", href: "/cli" },
-      { title: "Configuration", href: "/configuration" },
+      { title: 'CLI', href: '/cli' },
+      { title: 'Configuration', href: '/configuration' },
     ],
   },
   {
-    title: "Deployment",
-    items: [{ title: "Deploy Rex", href: "/deployment" }],
+    title: 'Deployment',
+    items: [{ title: 'Deploy Rex', href: '/deployment' }],
   },
 ];
 
 export default function Sidebar() {
   const [open, setOpen] = useState(false);
-  const [pathname, setPathname] = useState("");
+  const [pathname, setPathname] = useState('');
 
   useEffect(() => {
     setPathname(window.location.pathname);
@@ -64,8 +65,8 @@ export default function Sidebar() {
     function onPopState() {
       setPathname(window.location.pathname);
     }
-    window.addEventListener("popstate", onPopState);
-    return () => window.removeEventListener("popstate", onPopState);
+    window.addEventListener('popstate', onPopState);
+    return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
   const handleNavClick = useCallback(() => {
@@ -93,21 +94,20 @@ export default function Sidebar() {
       </button>
 
       {open && (
-        <div
-          className="lg:hidden fixed inset-0 bg-black/30 z-30"
-          onClick={() => setOpen(false)}
-        />
+        <div className="lg:hidden fixed inset-0 bg-black/30 z-30" onClick={() => setOpen(false)} />
       )}
 
       <aside
         className={`fixed top-0 left-0 z-40 h-full w-64 bg-slate-900 text-slate-300 overflow-y-auto transition-transform lg:translate-x-0 ${
-          open ? "translate-x-0" : "-translate-x-full"
+          open ? 'translate-x-0' : '-translate-x-full'
         }`}
       >
         <div className="px-5 py-5 border-b border-slate-700">
           <Link href="/" className="flex items-center gap-2 no-underline">
             <span className="text-xl font-bold text-emerald-400">Rex</span>
-            <span className="text-xs text-slate-500 font-mono mt-1">docs</span>
+            <span className="text-xs text-slate-500 font-mono mt-1">
+              docs{VERSION !== 'dev' ? ` · v${VERSION}` : ''}
+            </span>
           </Link>
         </div>
 
@@ -126,8 +126,8 @@ export default function Sidebar() {
                         href={item.href}
                         className={`block px-2 py-1.5 rounded text-sm transition-colors no-underline ${
                           active
-                            ? "text-white bg-slate-800"
-                            : "text-slate-400 hover:text-white hover:bg-slate-800"
+                            ? 'text-white bg-slate-800'
+                            : 'text-slate-400 hover:text-white hover:bg-slate-800'
                         }`}
                       >
                         {item.title}

--- a/docs/lib/version.ts
+++ b/docs/lib/version.ts
@@ -1,0 +1,2 @@
+// Overwritten during CI builds with the actual version.
+export const VERSION = 'dev';


### PR DESCRIPTION
## Summary
- Adds the current Rex version to the docs sidebar next to "Rex docs" (shows `docs · v0.19.3` in production, hidden in local dev)
- Extracts docs build + deploy into a reusable `deploy-docs.yml` workflow, called by both `docs.yml` (on docs content changes) and `release-please.yml` (after a production release)
- Fixes beta version computation to derive the theoretical next version from conventional commits since the last tag (e.g. `feat:` → minor bump), instead of reusing the current manifest version
- Adds `deploy-docs` job to the release workflow that runs after all other jobs (docker, npm, smoke tests, railway, cargo) succeed

## Changes
- **New**: `.github/workflows/deploy-docs.yml` — reusable workflow accepting `version` and `docker-tag` inputs
- **New**: `docs/lib/version.ts` — version constant (defaults to `"dev"`, overwritten by CI)
- **Modified**: `docs/components/Sidebar.tsx` — imports and displays version
- **Modified**: `.github/workflows/docs.yml` — simplified to call reusable workflow
- **Modified**: `.github/workflows/beta-release.yml` — computes next version from conventional commits
- **Modified**: `.github/workflows/release-please.yml` — adds version output + deploy-docs job

## Test plan
- [ ] Verify docs.yml workflow triggers correctly on docs/** changes
- [ ] Verify beta version computation produces correct next version (e.g. feat: → minor bump)
- [ ] Verify release workflow deploys docs after all other jobs complete
- [ ] Verify sidebar shows version in CI builds and hides it in local dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)