### PR TITLE
Potential fix for code scanning alert no. 40: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -13,6 +13,11 @@ on:
         type: string
         default: "latest-build"
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 concurrency:
   group: pages
   cancel-in-progress: false


### PR DESCRIPTION
Potential fix for [https://github.com/limlabs/rex/security/code-scanning/40](https://github.com/limlabs/rex/security/code-scanning/40)

In general, the fix is to add an explicit `permissions:` block limiting the `GITHUB_TOKEN` to only what the workflow needs, either at the top (applying to all jobs) or per job. For GitHub Pages deployments, GitHub recommends specific minimal permissions: typically `contents: read` for checkout, and `pages: write` plus `id-token: write` for deployment using `actions/deploy-pages`. Since this workflow builds docs and deploys them to Pages, we can safely set restrictive, explicit permissions at the workflow root so both jobs inherit them.

The best fix without changing existing functionality is to add a top-level `permissions:` block after the `on:` section. For a Pages deployment using `actions/deploy-pages@v4`, GitHub’s docs suggest:

```yaml
permissions:
  contents: read
  pages: write
  id-token: write
```

`contents: read` is required for `actions/checkout@v4` in the `build` job. `pages: write` and `id-token: write` are required for `actions/deploy-pages@v4` in the `deploy` job so that it can upload and publish the built site and use OIDC as needed. No additional imports or methods are required; this is purely a YAML configuration change in `.github/workflows/deploy-docs.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
