### PR TITLE
fix(build): out-of-root @source directives + parenthesized arbitrary values (#246, #248)

### DIFF
--- a/crates/rex_build/src/tailwind_scan.rs
+++ b/crates/rex_build/src/tailwind_scan.rs
@@ -3,7 +3,10 @@ use rex_core::RexConfig;
 use rex_router::ScanResult;
 use std::collections::HashSet;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+
+/// Directories never worth scanning for Tailwind candidates.
+const SKIP_DIRS: &[&str] = &["node_modules", ".rex", ".git", ".next", "public", "dist"];
 
 /// Scan all project source files and extract Tailwind utility class candidates.
 ///
@@ -61,11 +64,125 @@ fn collect_source_files(config: &RexConfig, scan: &ScanResult) -> Vec<PathBuf> {
     // This matches Tailwind v4's automatic content detection behavior.
     scan_project_root(&config.project_root, &mut files);
 
+    // Honor Tailwind v4 `@source` directives in the project's CSS entry files.
+    // Unlike the project-root walk above, these may reference files OUTSIDE
+    // `project_root` (e.g. a sibling monorepo package) — exactly the case the
+    // root walk misses (issue #246).
+    collect_source_directive_files(scan, &mut files);
+
     // Deduplicate
     let mut seen = HashSet::new();
     files.retain(|f| seen.insert(f.clone()));
 
     files
+}
+
+/// Collect source files referenced by Tailwind v4 `@source "<path>"` directives
+/// in the project's CSS entry files.
+///
+/// Tailwind's built-in V8 compiler is handed a pre-scanned candidate list, so it
+/// never performs its own filesystem scan of `@source` paths — that scan has to
+/// happen here. Paths are resolved relative to the CSS file's own directory (NOT
+/// `project_root`) and are added without any project-root restriction. The
+/// file-path forms are honored:
+///   - `@source "../shared/components"`     → recursive directory walk
+///   - `@source "../shared/components/"`    → recursive directory walk
+///   - `@source "../shared/**/*.{ts,tsx}"`  → walk the pre-glob base directory
+///   - `@source "../shared/Button.tsx"`     → single file
+///
+/// `@source inline("…")` is intentionally skipped: its candidates are embedded in
+/// the CSS and emitted by the Tailwind engine itself. `@source not "…"`
+/// exclusions are also left as no-ops.
+fn collect_source_directive_files(scan: &ScanResult, files: &mut Vec<PathBuf>) {
+    let css_paths = match crate::tailwind::collect_all_css_import_paths(scan) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    for css_path in &css_paths {
+        let content = match fs::read_to_string(css_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        if !crate::tailwind::needs_tailwind(&content) {
+            continue;
+        }
+        let css_dir = css_path.parent().unwrap_or_else(|| Path::new("."));
+        for body in parse_source_directives(&content) {
+            add_source_directive(css_dir, &body, files);
+        }
+    }
+}
+
+/// Extract the body of each `@source` at-rule (the text between `@source` and the
+/// terminating `;`). Commented-out directives are not special-cased — a stray
+/// match merely scans a few extra files, which is harmless given the candidate
+/// scanner is intentionally over-inclusive.
+fn parse_source_directives(css: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut rest = css;
+    while let Some(idx) = rest.find("@source") {
+        let after = &rest[idx + "@source".len()..];
+        // Require whitespace right after `@source` so we don't match `@sources`.
+        if !after.chars().next().is_some_and(char::is_whitespace) {
+            rest = after;
+            continue;
+        }
+        let end = after.find(';').unwrap_or(after.len());
+        let body = after[..end].trim();
+        if !body.is_empty() {
+            out.push(body.to_string());
+        }
+        rest = &after[end..];
+    }
+    out
+}
+
+/// Resolve one `@source` directive body to source files and add them to `files`.
+fn add_source_directive(css_dir: &Path, body: &str, files: &mut Vec<PathBuf>) {
+    let body = body.trim();
+    // Exclusions (`not …`) and inline safelists (`inline(…)`) are handled by the
+    // Tailwind engine itself; the candidate scanner skips them.
+    if body.starts_with("not") || body.starts_with("inline") {
+        return;
+    }
+    let path = match unquote(body) {
+        Some(p) => p,
+        None => return,
+    };
+    let (base, has_glob) = split_glob_base(path);
+    let resolved = css_dir.join(base);
+    if has_glob || resolved.is_dir() {
+        scan_directory_filtered(&resolved, files, SKIP_DIRS);
+    } else if resolved.is_file() {
+        files.push(resolved);
+    }
+}
+
+/// Strip a single- or double-quoted wrapper, returning the inner string.
+fn unquote(s: &str) -> Option<&str> {
+    let s = s.trim();
+    let quote = match s.chars().next()? {
+        c @ ('"' | '\'') => c,
+        _ => return None,
+    };
+    let inner = &s[quote.len_utf8()..];
+    let end = inner.find(quote)?;
+    Some(&inner[..end])
+}
+
+/// Split a `@source` path into its non-glob base directory and whether a glob
+/// pattern followed. Mirrors Tailwind v4: everything before the first path
+/// segment containing a glob metacharacter is the base directory that gets
+/// scanned.
+fn split_glob_base(path: &str) -> (String, bool) {
+    let mut base = Vec::new();
+    for segment in path.split('/') {
+        if segment.contains(['*', '?', '[', ']', '{', '}']) {
+            return (base.join("/"), true);
+        }
+        base.push(segment);
+    }
+    (base.join("/"), false)
 }
 
 /// Scan the project root for source files, skipping non-source directories.
@@ -74,7 +191,6 @@ fn collect_source_files(config: &RexConfig, scan: &ScanResult) -> Vec<PathBuf> {
 /// `src/`) are included in Tailwind candidate scanning — matching Tailwind v4's
 /// automatic content detection.
 fn scan_project_root(root: &std::path::Path, files: &mut Vec<PathBuf>) {
-    const SKIP_DIRS: &[&str] = &["node_modules", ".rex", ".git", ".next", "public", "dist"];
     scan_directory_filtered(root, files, SKIP_DIRS);
 }
 
@@ -286,6 +402,181 @@ mod tests {
         assert!(
             !names.iter().any(|n| n.contains("node_modules")),
             "should skip node_modules, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_parse_source_directives() {
+        let css = "@import \"tailwindcss\";\n\
+                   @source \"../shared\";\n\
+                   @source inline(\"foo bar\");\n\
+                   @source not \"../excluded\";\n";
+        assert_eq!(
+            parse_source_directives(css),
+            vec![
+                "\"../shared\"".to_string(),
+                "inline(\"foo bar\")".to_string(),
+                "not \"../excluded\"".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_source_directives_ignores_non_directive_token() {
+        // `@sources` (no whitespace) must not be treated as a directive.
+        let css = "@sources nothing;\n@source \"./real\";\n";
+        assert_eq!(parse_source_directives(css), vec!["\"./real\"".to_string()]);
+    }
+
+    #[test]
+    fn test_unquote() {
+        assert_eq!(unquote("\"abc\""), Some("abc"));
+        assert_eq!(unquote("'abc'"), Some("abc"));
+        assert_eq!(unquote("  \"abc\"  "), Some("abc"));
+        assert_eq!(unquote("abc"), None);
+        assert_eq!(unquote("\"unterminated"), None);
+    }
+
+    #[test]
+    fn test_split_glob_base() {
+        assert_eq!(
+            split_glob_base("../shared/src/components"),
+            ("../shared/src/components".to_string(), false)
+        );
+        assert_eq!(
+            split_glob_base("../shared/src/**/*.{ts,tsx}"),
+            ("../shared/src".to_string(), true)
+        );
+        assert_eq!(
+            split_glob_base("../shared/*.tsx"),
+            ("../shared".to_string(), true)
+        );
+    }
+
+    #[test]
+    fn test_add_source_directive_skips_inline_and_not() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let mut files = Vec::new();
+        add_source_directive(tmp.path(), "inline(\"foo bar\")", &mut files);
+        add_source_directive(tmp.path(), "not \"./x\"", &mut files);
+        assert!(
+            files.is_empty(),
+            "inline/not directives add no files: {files:?}"
+        );
+    }
+
+    #[test]
+    fn test_add_source_directive_walks_directory() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let comp = tmp.path().join("shared/components");
+        fs::create_dir_all(&comp).unwrap();
+        fs::write(comp.join("Card.tsx"), "className=\"text-emerald-600\"").unwrap();
+        // node_modules under the source dir must still be skipped.
+        let nm = comp.join("node_modules");
+        fs::create_dir_all(&nm).unwrap();
+        fs::write(nm.join("dep.js"), "className=\"should-not-appear\"").unwrap();
+
+        let css_dir = tmp.path().join("app/styles");
+        fs::create_dir_all(&css_dir).unwrap();
+
+        let mut files = Vec::new();
+        add_source_directive(&css_dir, "\"../../shared/components\"", &mut files);
+
+        let names: Vec<String> = files.iter().map(|f| f.display().to_string()).collect();
+        assert!(
+            names.iter().any(|n| n.contains("Card.tsx")),
+            "should walk the @source directory, got: {names:?}"
+        );
+        assert!(
+            !names.iter().any(|n| n.contains("node_modules")),
+            "should skip node_modules inside @source dir, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn test_add_source_directive_single_file() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let comp = tmp.path().join("shared");
+        fs::create_dir_all(&comp).unwrap();
+        let file = comp.join("Only.tsx");
+        fs::write(&file, "className=\"p-7\"").unwrap();
+
+        let css_dir = tmp.path().join("app");
+        fs::create_dir_all(&css_dir).unwrap();
+
+        let mut files = Vec::new();
+        add_source_directive(&css_dir, "\"../shared/Only.tsx\"", &mut files);
+        assert_eq!(files.len(), 1);
+        assert!(files[0].ends_with("Only.tsx"));
+    }
+
+    /// Regression for #246: a class used only in a sibling package referenced via
+    /// an out-of-root `@source` directive must still end up in the candidate set.
+    #[test]
+    fn test_scan_candidates_honors_out_of_root_at_source() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // project_root = <tmp>/app ; sibling package = <tmp>/shared
+        let app = tmp.path().join("app");
+        let pages = app.join("pages");
+        let styles = app.join("styles");
+        fs::create_dir_all(&pages).unwrap();
+        fs::create_dir_all(&styles).unwrap();
+        let shared_components = tmp.path().join("shared/src/components");
+        fs::create_dir_all(&shared_components).unwrap();
+
+        // CSS entry imports Tailwind and points @source at the sibling package.
+        fs::write(
+            styles.join("globals.css"),
+            "@import \"tailwindcss\";\n@source \"../../shared/src/components\";\n",
+        )
+        .unwrap();
+
+        // _app imports the CSS; it does NOT use the sibling-only class.
+        let app_entry = pages.join("_app.tsx");
+        fs::write(
+            &app_entry,
+            "import '../styles/globals.css';\nexport default function App() { return null; }\n",
+        )
+        .unwrap();
+
+        // The sibling component is the ONLY place this class appears.
+        fs::write(
+            shared_components.join("Widget.tsx"),
+            "export default function Widget() { return <div className=\"bg-fuchsia-700\">hi</div>; }",
+        )
+        .unwrap();
+
+        let config = rex_core::RexConfig {
+            project_root: app.clone(),
+            pages_dir: pages.clone(),
+            app_dir: app.join("app"),
+            output_dir: app.join(".rex"),
+            port: 3000,
+            dev: false,
+        };
+        let scan = rex_router::ScanResult {
+            app: Some(rex_core::Route {
+                pattern: "/_app".to_string(),
+                file_path: app_entry.clone(),
+                abs_path: app_entry,
+                dynamic_segments: vec![],
+                page_type: rex_core::PageType::Regular,
+                specificity: 0,
+            }),
+            routes: vec![],
+            not_found: None,
+            error: None,
+            document: None,
+            middleware: None,
+            mcp_tools: vec![],
+            api_routes: vec![],
+            app_scan: None,
+        };
+
+        let candidates = scan_candidates(&config, &scan).unwrap();
+        assert!(
+            candidates.iter().any(|c| c == "bg-fuchsia-700"),
+            "out-of-root @source should contribute its candidates, got: {candidates:?}"
         );
     }
 }

--- a/crates/rex_build/src/tailwind_scan.rs
+++ b/crates/rex_build/src/tailwind_scan.rs
@@ -229,16 +229,48 @@ fn is_scannable(path: &std::path::Path) -> bool {
 /// word-like tokens. Over-inclusion is intentional — the Tailwind compiler
 /// ignores candidates that don't match any utility definition.
 fn scan_source(source: &str, candidates: &mut HashSet<String>) {
-    // Split on delimiters that can't be part of CSS class names
-    for token in source.split(is_delimiter) {
-        let token = token.trim();
-        if is_candidate(token) {
-            candidates.insert(token.to_string());
+    // Split on delimiters that can't be part of CSS class names. Parentheses are
+    // a special case: they delimit tokens only OUTSIDE arbitrary-value brackets.
+    // That keeps call-expression syntax splitting cleanly (`cn("flex", …)` yields
+    // `cn` + `flex`, not `cn(`) while letting arbitrary values that embed CSS
+    // functions survive intact — e.g. `text-[var(--color-accent)]`,
+    // `w-[calc(100%-2rem)]`, `bg-[image:theme(colors.red)]`. Without this, the
+    // built-in compiler would never emit those utilities (issue: parenthesized
+    // arbitrary values dropped during candidate scanning).
+    let mut token_start: Option<usize> = None;
+    let mut bracket_depth: u32 = 0;
+    for (i, c) in source.char_indices() {
+        match c {
+            '[' => bracket_depth += 1,
+            ']' => bracket_depth = bracket_depth.saturating_sub(1),
+            _ => {}
         }
+        let delimits = is_delimiter(c) || (bracket_depth == 0 && matches!(c, '(' | ')'));
+        if delimits {
+            if let Some(start) = token_start.take() {
+                insert_candidate(&source[start..i], candidates);
+            }
+        } else if token_start.is_none() {
+            token_start = Some(i);
+        }
+    }
+    if let Some(start) = token_start {
+        insert_candidate(&source[start..], candidates);
     }
 }
 
-/// Characters that delimit tokens (can't appear in utility class names).
+/// Trim a raw token and add it to the candidate set if it looks like a utility.
+fn insert_candidate(token: &str, candidates: &mut HashSet<String>) {
+    let token = token.trim();
+    if is_candidate(token) {
+        candidates.insert(token.to_string());
+    }
+}
+
+/// Characters that unconditionally delimit tokens (can't appear in utility class
+/// names). Parentheses are handled contextually in [`scan_source`] — they are
+/// delimiters only outside `[…]` arbitrary values — so they are deliberately
+/// absent here.
 fn is_delimiter(c: char) -> bool {
     matches!(
         c,
@@ -250,8 +282,6 @@ fn is_delimiter(c: char) -> bool {
             | '\r'
             | '{'
             | '}'
-            | '('
-            | ')'
             | '<'
             | '>'
             | '='
@@ -348,6 +378,58 @@ mod tests {
         scan_source(r#"className="w-[200px] bg-[#ff0000]""#, &mut candidates);
         assert!(candidates.contains("w-[200px]"));
         assert!(candidates.contains("bg-[#ff0000]"));
+    }
+
+    #[test]
+    fn test_scan_arbitrary_values_with_parentheses() {
+        // Arbitrary values that embed CSS functions must survive tokenization —
+        // the parentheses must NOT split them. Regression for parenthesized
+        // arbitrary values being dropped during candidate scanning.
+        let mut candidates = HashSet::new();
+        scan_source(
+            r#"className="text-[var(--color-accent)] w-[calc(100%-2rem)] bg-[image:theme(colors.red)]""#,
+            &mut candidates,
+        );
+        assert!(
+            candidates.contains("text-[var(--color-accent)]"),
+            "var() arbitrary value must survive, got: {candidates:?}"
+        );
+        assert!(
+            candidates.contains("w-[calc(100%-2rem)]"),
+            "calc() arbitrary value must survive, got: {candidates:?}"
+        );
+        assert!(
+            candidates.contains("bg-[image:theme(colors.red)]"),
+            "theme() arbitrary value must survive, got: {candidates:?}"
+        );
+    }
+
+    #[test]
+    fn test_scan_variant_arbitrary_value_with_parens() {
+        // The real-world pantry-host case: a `hover:` variant on a parenthesized
+        // arbitrary value (`hover:text-[var(--color-accent)]`).
+        let mut candidates = HashSet::new();
+        scan_source(
+            r#"<a className="hover:text-[var(--color-accent)]">link</a>"#,
+            &mut candidates,
+        );
+        assert!(
+            candidates.contains("hover:text-[var(--color-accent)]"),
+            "variant + parenthesized arbitrary value must survive, got: {candidates:?}"
+        );
+    }
+
+    #[test]
+    fn test_scan_clsx_with_conditional_and_parens() {
+        // Parentheses outside `[…]` still delimit, so `cn(`/`)` don't pollute the
+        // real classes — `flex` and `p-4` come through cleanly.
+        let mut candidates = HashSet::new();
+        scan_source(r#"cn("flex", x && "p-4")"#, &mut candidates);
+        assert!(candidates.contains("flex"));
+        assert!(candidates.contains("p-4"));
+        // The call expression itself is split on its parens, so the bare
+        // function name is the clean token (never `cn(`).
+        assert!(!candidates.contains("cn("));
     }
 
     #[test]

--- a/crates/rex_e2e/tests/tailwind_e2e.rs
+++ b/crates/rex_e2e/tests/tailwind_e2e.rs
@@ -260,6 +260,20 @@ mod tailwind {
 
     #[tokio::test]
     #[ignore]
+    async fn e2e_tailwind_css_includes_out_of_root_source() {
+        // Regression for limlabs/rex#246: globals.css references a sibling package
+        // outside the app's project root via `@source "../../tailwind-builtin-shared"`.
+        // `bg-rose-700` is used ONLY in that sibling (fixtures/tailwind-builtin-shared),
+        // so it appears here only if the out-of-root @source directive is honored.
+        let css = get_tailwind_css().await;
+        assert!(
+            css.contains(".bg-rose-700"),
+            "CSS should contain .bg-rose-700 from the out-of-root @source package"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
     async fn e2e_tailwind_ssr_renders_class_attributes() {
         // Verify the SSR HTML contains the Tailwind class names in the rendered markup
         let url = format!("{}/", base_url());

--- a/crates/rex_e2e/tests/tailwind_e2e.rs
+++ b/crates/rex_e2e/tests/tailwind_e2e.rs
@@ -274,6 +274,25 @@ mod tailwind {
 
     #[tokio::test]
     #[ignore]
+    async fn e2e_tailwind_css_includes_parenthesized_arbitrary_value() {
+        // Regression: a utility whose arbitrary value embeds a CSS function —
+        // `text-[var(--color-accent)]` in index.tsx — must be emitted by the
+        // built-in compiler WITHOUT any `@source inline(...)` safelist. The
+        // candidate scanner previously split on `(`/`)`, dropping the utility.
+        let css = get_tailwind_css().await;
+        // The escaped selector only appears if the parenthesized arbitrary value
+        // survived candidate tokenization; the unescaped `var(--color-accent)` is
+        // the compiled declaration value. Both substrings are format-independent
+        // (dev pretty-prints, `build` minifies).
+        assert!(
+            css.contains(r"text-\[var\(--color-accent\)\]") && css.contains("var(--color-accent)"),
+            "CSS should contain the escaped `.text-\\[var\\(--color-accent\\)\\]` rule \
+             (compiled from a parenthesized arbitrary value with no inline safelist)"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
     async fn e2e_tailwind_ssr_renders_class_attributes() {
         // Verify the SSR HTML contains the Tailwind class names in the rendered markup
         let url = format!("{}/", base_url());

--- a/fixtures/tailwind-builtin-shared/Badge.tsx
+++ b/fixtures/tailwind-builtin-shared/Badge.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+// This component lives OUTSIDE the tailwind-builtin app's project root. It is
+// reachable only through an out-of-root `@source "../../tailwind-builtin-shared"`
+// directive in the app's globals.css. The `bg-rose-700` utility below is used
+// nowhere else, so it appears in the compiled CSS only if Rex honors that
+// out-of-root @source directive (regression guard for limlabs/rex#246).
+export default function Badge() {
+  return <span className="bg-rose-700 text-white rounded px-2 py-1">Shared</span>;
+}

--- a/fixtures/tailwind-builtin/pages/index.tsx
+++ b/fixtures/tailwind-builtin/pages/index.tsx
@@ -11,6 +11,13 @@ export default function Home({ message, timestamp }: Props) {
       <h1 className="text-4xl font-bold text-gray-900 mb-4">Tailwind Builtin</h1>
       <p className="text-lg text-gray-600 mb-2">{message}</p>
       <p className="text-sm text-gray-400">Rendered at: {timestamp}</p>
+      {/* Arbitrary value embedding a CSS function. The parentheses inside the
+          `[…]` must survive candidate scanning, so the built-in compiler emits
+          `.text-\[var\(--color-accent\)\]` without any `@source inline(...)`
+          safelist. */}
+      <p className="text-[var(--color-accent)] hover:text-[var(--color-accent)]">
+        Accent text via an arbitrary CSS variable
+      </p>
       <div className="mt-8 grid grid-cols-2 gap-4">
         <div className="bg-white rounded-lg shadow p-6">
           <h2 className="text-xl font-semibold mb-2">Zero Install</h2>

--- a/fixtures/tailwind-builtin/styles/globals.css
+++ b/fixtures/tailwind-builtin/styles/globals.css
@@ -1,1 +1,5 @@
 @import "tailwindcss";
+
+/* Pull in a sibling package that lives OUTSIDE this app's project root.
+   Exercises Tailwind v4 out-of-root `@source` support (limlabs/rex#246). */
+@source "../../tailwind-builtin-shared";


### PR DESCRIPTION
## Summary

This PR bundles **two related fixes** to the built-in (V8) Tailwind candidate
scanner in `crates/rex_build/src/tailwind_scan.rs`. Both affect only the default
built-in compiler used by `rex build`/`rex dev`; the opt-in `tailwindcss` CLI
path already handles both natively.

1. **Fixes #246** — out-of-root `@source` directives were ignored, so utility
   classes used only in files **outside the app package root** (e.g. a sibling
   monorepo package) were never generated.
2. **Fixes #248** — utility classes whose *arbitrary value* contains parentheses
   (e.g. `text-[var(--color-accent)]`) were dropped during candidate
   tokenization.

---

## Fix 1 — honor out-of-root `@source` directives (#246)

Rex's built-in Tailwind build ignored `@source` directives, so utility classes
used only in files **outside the app package root** were never generated.

### Root cause

`tailwind_scan.rs` built the candidate list purely by walking
`config.project_root` (`scan_project_root`). It never parsed the CSS's `@source`
directives, so any `@source` resolving outside `project_root` was a silent
no-op:

- `@source "../../shared/src/components"` (bare path) → nothing
- `@source "../../shared/src/components/"` (trailing slash) → nothing
- `@source "../../shared/src/**/*.{ts,tsx}"` (glob) → nothing

Only `@source inline("…")` worked — its candidates are embedded in the CSS and
emitted by the Tailwind engine itself, not by this Rust scanner. That's why the
current workaround is an inline safelist.

### The fix

Parse `@source "<path>"` directives from each Tailwind CSS entry file and add the
referenced files to the candidate scan:

1. Resolve each path **relative to the CSS file's own directory** (not
   `project_root`).
2. Add matches **without** restricting to `project_root`.
3. Support a directory (recursive walk reusing `SKIP_DIRS` + `is_scannable`), a
   trailing-slash directory, an explicit glob (its pre-glob base directory is
   walked), and a single file.
4. Keep the existing project-root auto-detection as the default (no regression)
   and keep dedup.
5. `@source not "…"` exclusions and `@source inline(…)` safelists are left to the
   Tailwind engine.

No new Tailwind syntax is invented — this mirrors Tailwind v4's `@source`
file-path semantics.

### Real-world verification

Reproduced against a real npm-workspaces consumer where `packages/app` is the
Rex app and `packages/shared` is a sibling package. With the inline safelist
**removed** (leaving only `@source "../../shared/src/components"`), a build with
the patched binary now generates the previously-missing classes:

```
.list-disc{list-style-type:disc}
.pl-5{padding-left:calc(var(--spacing) * 5)}
.grid-cols-4{@media (width>=80rem){grid-template-columns:repeat(4,minmax(0,1fr))}}
```

Before this change, those are absent unless safelisted via `@source inline(...)`.

### Tests

- **Unit**: directive parsing, quote stripping, glob-base splitting, `not`/`inline`
  skipping, directory walk (incl. `node_modules` skip), and single-file resolution.
- **Integration**: `test_scan_candidates_honors_out_of_root_at_source` builds a
  realistic monorepo layout (`app/styles/globals.css` with
  `@source "../../shared/src/components"`, a class used only in the sibling) and
  asserts the class lands in the collected candidates.
- **E2E**: `e2e_tailwind_css_includes_out_of_root_source` plus a sibling fixture
  `fixtures/tailwind-builtin-shared/` referenced via
  `@source "../../tailwind-builtin-shared"`, asserting `.bg-rose-700` (used only
  in the sibling) ends up in the compiled CSS.

---

## Fix 2 — keep parenthesized arbitrary values (#248)

Utility classes whose arbitrary value embeds a CSS function were silently dropped
from scanned source, regardless of whether reached via `@source` or the normal
project-root walk — independent of Fix 1.

### Root cause

`is_delimiter` listed `(` and `)` as token delimiters, so `scan_source` split
`text-[var(--color-accent)]` into `text-[var`, `--color-accent`, `]` — none of
which match the utility. Affected examples: `text-[var(--color-accent)]`,
`w-[calc(100%-2rem)]`, `bg-[image:theme(colors.red)]`, and variants like
`hover:text-[var(--color-accent)]`.

### The fix

Make `scan_source` **bracket-depth aware**: `(`/`)` delimit tokens only
**outside** `[…]` arbitrary values. Parenthesized values now survive
tokenization, while `cn(...)`/`clsx(...)` extraction still splits cleanly
(yielding the `cn` token, not `cn(`). Quotes, spaces, and commas remain
delimiters.

### Tests

- **Unit**: `test_scan_arbitrary_values_with_parentheses`,
  `test_scan_variant_arbitrary_value_with_parens` (the `hover:` variant), and
  `test_scan_clsx_with_conditional_and_parens`; the existing `test_scan_clsx`
  still passes.
- **E2E**: `e2e_tailwind_css_includes_parenthesized_arbitrary_value` — the
  fixture uses `text-[var(--color-accent)]` and the test asserts the compiled
  CSS contains `.text-\[var\(--color-accent\)\]{color:var(--color-accent)}` with
  **no** inline safelist.

---

All existing `rex_build` tests and the full `tailwind_e2e` suite pass;
`cargo fmt --check` and `cargo clippy -- -D warnings` are clean.

## Notes

- `@source inline("…")` already works and remains the workaround for releases
  prior to these fixes.
- **Remaining tokenizer limitation (follow-up):** other always-delimiters
  (`,`, `>`, …) still split inside `[…]`, so arbitrary values containing them —
  e.g. `grid-cols-[repeat(2,minmax(0,1fr))]`, `[&>div]:flex` — are still dropped.
  Tracked in the "out of scope" section of #248.

Closes #246
Closes #248
