### PR TITLE
fix(build): isolate per-build scratch dirs to stop flaky dev output-dir race

### DIFF
--- a/crates/rex_build/src/build_utils.rs
+++ b/crates/rex_build/src/build_utils.rs
@@ -1,9 +1,29 @@
 use anyhow::Result;
 use std::fs;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 // Re-export detection functions from page_exports for backward compatibility
 pub(crate) use crate::page_exports::{detect_data_strategy, extract_middleware_matchers};
+
+/// Monotonic counter that makes per-build scratch directories unique.
+static SCRATCH_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// Return a process-unique scratch directory path under `output_dir` using the
+/// given `prefix` (e.g. `_dce`, `_entries`, `_server_entry`). The directory is
+/// NOT created — callers `create_dir_all` it themselves.
+///
+/// Builds write transient inputs (DCE'd page copies, virtual entry files) into
+/// these dirs and `remove_dir_all` them on completion. When two builds overlap
+/// on the same `output_dir` — e.g. a dev-server init build that gets cancelled
+/// by a dropped HTTP connection and is then restarted — a shared, fixed scratch
+/// path means one build's cleanup deletes the other's in-flight files, which
+/// surfaces to rolldown as `UNLOADABLE_DEPENDENCY`. A unique suffix per
+/// invocation isolates each build's scratch so cleanup can never cross builds.
+pub(crate) fn unique_scratch_dir(output_dir: &Path, prefix: &str) -> PathBuf {
+    let seq = SCRATCH_SEQ.fetch_add(1, Ordering::Relaxed);
+    output_dir.join(format!("{prefix}-{seq}"))
+}
 
 /// Map a route to a chunk name for rolldown entry naming.
 pub(crate) fn route_to_chunk_name(route: &rex_core::Route) -> String {
@@ -259,6 +279,27 @@ mod tests {
     fn test_route_to_chunk_name_index() {
         let route = make_route("/", "index.tsx");
         assert_eq!(route_to_chunk_name(&route), "index");
+    }
+
+    #[test]
+    fn test_unique_scratch_dir_paths_are_distinct() {
+        let out = PathBuf::from("/tmp/out");
+        let a = unique_scratch_dir(&out, "_dce");
+        let b = unique_scratch_dir(&out, "_dce");
+        assert_ne!(
+            a, b,
+            "each call must yield a distinct dir so overlapping builds never \
+             share — and thus never delete each other's — scratch files"
+        );
+        // Both live under the output dir and carry the requested prefix.
+        for p in [&a, &b] {
+            assert_eq!(p.parent().unwrap(), out.as_path());
+            assert!(p
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .starts_with("_dce-"));
+        }
     }
 
     #[test]

--- a/crates/rex_build/src/bundler.rs
+++ b/crates/rex_build/src/bundler.rs
@@ -91,8 +91,18 @@ pub async fn build_bundles_with_id(
     // Clean output directories to remove stale artifacts from previous builds.
     // Use let _ to ignore errors — on macOS, remove_dir_all can race with
     // Spotlight/fsevents and fail with ENOTEMPTY (os error 66).
-    let _ = fs::remove_dir_all(&server_dir);
-    let _ = fs::remove_dir_all(&client_dir);
+    //
+    // Only wipe for production builds, which are single-shot with no concurrency.
+    // In dev, builds can overlap on the same output dir (an init build cancelled
+    // by a dropped HTTP connection then restarted, or rapid rebuilds), and a
+    // blanket wipe would delete another in-flight build's files mid-bundle —
+    // surfacing as rolldown `UNLOADABLE_DEPENDENCY`. Dev relies instead on
+    // content-hashed output names (stale chunks are unreferenced and harmless)
+    // plus per-build scratch dirs (see `unique_scratch_dir`).
+    if !config.dev {
+        let _ = fs::remove_dir_all(&server_dir);
+        let _ = fs::remove_dir_all(&client_dir);
+    }
     fs::create_dir_all(&server_dir)?;
     fs::create_dir_all(&client_dir)?;
 

--- a/crates/rex_build/src/client_bundle.rs
+++ b/crates/rex_build/src/client_bundle.rs
@@ -1,4 +1,6 @@
-use crate::build_utils::{find_route_for_chunk, route_to_chunk_name, runtime_client_dir};
+use crate::build_utils::{
+    find_route_for_chunk, route_to_chunk_name, runtime_client_dir, unique_scratch_dir,
+};
 use crate::css_collect::collect_css_files;
 use crate::css_modules::CssModuleProcessing;
 use crate::manifest::AssetManifest;
@@ -58,8 +60,10 @@ pub(crate) async fn build_client_bundles(
     // Runtime files for rex/link, rex/head aliases
     let runtime_dir = runtime_client_dir()?;
 
-    // Generate virtual entry files for rolldown
-    let entries_dir = output_dir.join("_entries");
+    // Generate virtual entry files for rolldown. Use a per-build scratch dir so
+    // overlapping builds (e.g. a cancelled-then-restarted dev init) can't delete
+    // each other's in-flight entry files via the cleanup below.
+    let entries_dir = unique_scratch_dir(output_dir, "_entries");
     fs::create_dir_all(&entries_dir)?;
 
     let mut inputs = Vec::new();
@@ -80,8 +84,8 @@ pub(crate) async fn build_client_bundles(
         });
     }
 
-    // Page entries (with server-export DCE)
-    let dce_dir = output_dir.join("_dce");
+    // Page entries (with server-export DCE). Per-build scratch dir (see above).
+    let dce_dir = unique_scratch_dir(output_dir, "_dce");
     fs::create_dir_all(&dce_dir)?;
 
     for route in &scan.routes {

--- a/crates/rex_build/src/server_bundle.rs
+++ b/crates/rex_build/src/server_bundle.rs
@@ -1,4 +1,4 @@
-use crate::build_utils::runtime_server_dir;
+use crate::build_utils::{runtime_server_dir, unique_scratch_dir};
 use anyhow::Result;
 use rex_core::{ProjectConfig, RexConfig};
 use rex_router::ScanResult;
@@ -385,8 +385,10 @@ pub(crate) async fn build_server_bundle(
 ) -> Result<PathBuf> {
     let runtime_dir = runtime_server_dir()?;
 
-    // Generate virtual entry that imports everything and registers on globalThis
-    let entries_dir = output_dir.join("_server_entry");
+    // Generate virtual entry that imports everything and registers on globalThis.
+    // Per-build scratch dir so overlapping builds don't delete each other's
+    // in-flight entry files via the cleanup at the end of this function.
+    let entries_dir = unique_scratch_dir(output_dir, "_server_entry");
     fs::create_dir_all(&entries_dir)?;
 
     let mut entry = String::new();

--- a/crates/rex_build/tests/build_output_dir_tests.rs
+++ b/crates/rex_build/tests/build_output_dir_tests.rs
@@ -1,0 +1,89 @@
+//! Regression tests for builds that overlap on the same output directory.
+//!
+//! In dev, the bundler's output dir is shared across builds. A `rex dev` init
+//! build can be cancelled by a dropped HTTP connection and then restarted (see
+//! `rex_server`'s lazy init), so two builds can be in flight against the same
+//! `.rex/build` dir at once. If a build wiped the whole output dir on start, or
+//! removed a fixed (shared) scratch dir on finish, one build's cleanup would
+//! delete another build's in-flight files mid-bundle — which surfaced to
+//! rolldown as `[UNLOADABLE_DEPENDENCY] Could not load .rex/build/client/_dce/
+//! <page>.tsx` and bubbled up as a flaky 500 / failing e2e test.
+//!
+//! The fix has two parts, each verified deterministically here:
+//!  1. Dev builds do NOT wipe the shared output dir (rely on content-hashed
+//!     names instead) — so a concurrent build's files survive. (Unit coverage of
+//!     the per-build scratch dirs lives in `build_utils`'s inline tests.)
+//!  2. Production builds, which are single-shot with no concurrency, still wipe.
+#![allow(clippy::unwrap_used)]
+
+mod common;
+
+use common::setup_test_project;
+use rex_core::ProjectConfig;
+use std::fs;
+
+const PAGES: &[(&str, &str)] = &[
+    (
+        "index.tsx",
+        "export default function Home() { return <div>Home</div>; }",
+    ),
+    // A dynamic page WITH a server export, so DCE writes a stripped
+    // `_dce/posts-_id_.tsx` scratch file — mirroring the page that failed in CI.
+    (
+        "posts/[id].tsx",
+        r#"
+        export async function getServerSideProps() {
+            return { props: { id: "x" } };
+        }
+        export default function Post({ id }) { return <div>{id}</div>; }
+        "#,
+    ),
+];
+
+/// A dev build must leave files written by a concurrent (overlapping) build
+/// alone — i.e. it must not wipe the shared output dir on start. Modeled by
+/// dropping a sentinel into the client output dir before building and asserting
+/// it survives. Before the fix, the start-of-build `remove_dir_all` deleted it.
+#[tokio::test]
+async fn dev_build_does_not_wipe_shared_output_dir() {
+    let (_tmp, config, scan) = setup_test_project(PAGES, None);
+    assert!(config.dev, "this regression covers the dev build path");
+
+    // Simulate a concurrently-running build's artifact already in the output dir.
+    let client_dir = config.client_build_dir();
+    fs::create_dir_all(&client_dir).unwrap();
+    let sentinel = client_dir.join("_concurrent_build_artifact.js");
+    fs::write(&sentinel, "// another build's in-flight file").unwrap();
+
+    build_bundles(&config, &scan).await;
+
+    assert!(
+        sentinel.exists(),
+        "dev build wiped the shared output dir, clobbering a concurrent build's file"
+    );
+}
+
+/// Production builds are single-shot, so they keep wiping stale artifacts.
+#[tokio::test]
+async fn production_build_wipes_stale_output_dir() {
+    let (_tmp, mut config, scan) = setup_test_project(PAGES, None);
+    config = config.with_dev(false);
+
+    let client_dir = config.client_build_dir();
+    fs::create_dir_all(&client_dir).unwrap();
+    let stale = client_dir.join("_stale_artifact.js");
+    fs::write(&stale, "// stale output from a previous build").unwrap();
+
+    build_bundles(&config, &scan).await;
+
+    assert!(
+        !stale.exists(),
+        "production build should wipe stale artifacts from the output dir"
+    );
+}
+
+async fn build_bundles(config: &rex_core::RexConfig, scan: &rex_router::ScanResult) {
+    rex_build::build_bundles(config, scan, &ProjectConfig::default())
+        .await
+        .unwrap();
+}


### PR DESCRIPTION
## Summary

Fixes the flaky e2e failure seen in #247 (`tests::e2e_404_page_returns_404`), where the dev server's init build intermittently failed with:

```
Initialization failed: Rolldown bundle failed:
[UNLOADABLE_DEPENDENCY] Error: Could not load .rex/build/client/_dce/posts-_id_.tsx
```

This had nothing to do with that PR's Tailwind changes — it's a pre-existing race in the build pipeline that surfaces under CI timing. (#247 has since merged, so the flake now lives on `main`.)

## Root cause

Two builds can run against the same `.rex/build` output dir at once:

- `rex dev`'s lazy init build runs inside a request future and **can be cancelled by a dropped HTTP connection, then restarted** (the comment at `state.rs` even calls this out). The e2e harness polls `GET /` with short-lived connections — exactly this pattern.
- Rapid rebuilds can also overlap.

When two builds overlap, two deletion vectors clobber in-flight files:

1. `build_bundles_with_id` wiped the **whole** output dir on start (`remove_dir_all` of the server/client dirs).
2. `build_client_bundles` / `build_server_bundle` wrote transient entry + DCE files into **fixed, shared** scratch dirs (`_entries`, `_dce`, `_server_entry`) and `remove_dir_all`'d them on finish.

Either one deletes the other build's `_dce/<page>.tsx` mid-bundle → rolldown `UNLOADABLE_DEPENDENCY` → a 500 during init → flaky test.

## Fix

- **Per-build scratch dirs** (`unique_scratch_dir`): each build invocation gets a process-unique `_dce-N` / `_entries-N` / `_server_entry-N`, so cleanup can never cross builds.
- **No destructive wipe in dev**: the start-of-build `remove_dir_all` stays for single-shot production builds but is skipped in dev. Dev relies on content-hashed output names instead — stale chunks are unreferenced and harmless, and skipping the wipe also avoids deleting chunks that an in-flight request is still serving. (Same approach Next.js takes for `.next` in dev.)

## Tests

- `build_utils`: unit test that `unique_scratch_dir` returns distinct paths.
- `build_output_dir_tests`: a dev build leaves a concurrent build's file in the output dir intact (**fails on pre-fix code** — verified by reverting the wipe gate and watching it panic with "dev build wiped the shared output dir"); a production build still wipes stale artifacts.

An earlier draft used a 6-way concurrent-build test, but it proved load-sensitive (under extreme CPU oversubscription rolldown itself panics on transient OS fs errors) — so it was replaced with the deterministic tests above. Introducing a flaky test to fix a flaky test would defeat the purpose.

## Verification

- `cargo test -p rex_build` green across 3 consecutive runs; `cargo fmt --check` and `cargo clippy --tests -- -D warnings` clean.
- Ran `rex dev` against `fixtures/basic`: `/`, `/about`, `/posts/first` → 200, unknown route → 404, HMR rebuild reflects edits, no scratch dirs left behind.

## Tradeoff / follow-up

Dev no longer wipes `.rex/build`, so stale content-hashed chunks accumulate over a long dev session (bounded per rebuild, all unreferenced). If that ever matters, a follow-up could GC chunks not referenced by the current manifest, instead of a blanket wipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)